### PR TITLE
Hero: konkrétnejší copy + rotujúci riadok schopností

### DIFF
--- a/app/components/HeroSection.vue
+++ b/app/components/HeroSection.vue
@@ -6,6 +6,30 @@ const panelItems = [
   { docKey: 'hero.panel.doc_delivery', vendor: 'Stavebniny Krajná', amount: '—', statusKey: 'hero.panel.status_review' },
   { docKey: 'hero.panel.doc_invoice', vendor: 'IT Servis Plus', amount: '345,50 €', statusKey: 'hero.panel.status_done' }
 ]
+
+const rotatingPhrases = computed(() => [
+  t('hero.rotator.item_1'),
+  t('hero.rotator.item_2'),
+  t('hero.rotator.item_3')
+])
+
+const activeIndex = ref(0)
+let timer: ReturnType<typeof setInterval> | undefined
+
+function startRotation() {
+  if (timer || window.matchMedia('(prefers-reduced-motion: reduce)').matches) return
+  timer = setInterval(() => {
+    activeIndex.value = (activeIndex.value + 1) % rotatingPhrases.value.length
+  }, 3500)
+}
+
+function stopRotation() {
+  clearInterval(timer)
+  timer = undefined
+}
+
+onMounted(startRotation)
+onUnmounted(stopRotation)
 </script>
 
 <template>
@@ -14,6 +38,16 @@ const panelItems = [
       <div class="hero__copy">
         <h1>{{ t('hero.title') }}</h1>
         <p>{{ t('hero.lead') }}</p>
+        <p
+          class="hero__rotator"
+          aria-live="polite"
+          @mouseenter="stopRotation"
+          @mouseleave="startRotation"
+        >
+          <Transition name="fade" mode="out-in">
+            <span :key="activeIndex">{{ rotatingPhrases[activeIndex] }}</span>
+          </Transition>
+        </p>
         <div class="hero__cta">
           <a href="#demo" class="btn-primary">{{ t('nav.cta_demo') }}</a>
           <a href="#kontakt" class="btn-secondary">{{ t('hero.cta_contact') }}</a>
@@ -65,6 +99,36 @@ const panelItems = [
   font-size: 1.05rem;
   margin: 0 0 1.75rem;
   max-width: 38rem;
+}
+
+.hero__rotator {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-height: 1.4rem;
+  margin: 0 0 1.75rem;
+  color: var(--color-accent);
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.hero__rotator::before {
+  content: '';
+  width: 0.4rem;
+  height: 0.4rem;
+  border-radius: 50%;
+  background: var(--color-accent);
+  flex-shrink: 0;
+}
+
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.3s ease;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
 }
 
 .hero__cta {

--- a/i18n/locales/cs.json
+++ b/i18n/locales/cs.json
@@ -27,8 +27,8 @@
     "gdpr_link": "Ochrana osobních údajů a cookies"
   },
   "hero": {
-    "title": "Faktury a doklady vám přepíše software, ne účetní.",
-    "lead": "Nahrajete nebo vyfotíte doklad, systém vytěží částky, dodavatele i datum splatnosti. Vy už jen zkontrolujete a schválíte zápis do účetnictví.",
+    "title": "Fakturu vyfotíte, systém ji přečte a založí v účetnictví.",
+    "lead": "Vytěží částku, dodavatele, IČO i datum splatnosti — vy si jen ověříte výsledek a kliknete na schválení. Funguje to s fakturami z e-mailu, naskenovanými i vyfocenými mobilem.",
     "cta_contact": "Napsat nám",
     "panel_caption": "Ukázka rozhraní — ilustrační data",
     "panel": {
@@ -36,6 +36,11 @@
       "doc_delivery": "Dodací list",
       "status_done": "Zpracováno",
       "status_review": "Čeká na kontrolu"
+    },
+    "rotator": {
+      "item_1": "Vytěží částky, IČO a splatnost z faktur.",
+      "item_2": "Odpovídá na otázky podle vašich interních dokumentů.",
+      "item_3": "Spouští opakované úkoly podle pravidel, která nastavíte."
     }
   }
 }

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -27,8 +27,8 @@
     "gdpr_link": "Privacy & cookies"
   },
   "hero": {
-    "title": "Software reads your invoices so your bookkeeper doesn't have to.",
-    "lead": "Upload or photograph a document and the system extracts the amounts, vendor, and due date. You just review and approve the entry into your accounting system.",
+    "title": "Photograph an invoice and the system reads it straight into your books.",
+    "lead": "It picks out the amount, vendor, tax ID, and due date — you just check the result and approve it. Works with invoices from email, scans, or a phone photo.",
     "cta_contact": "Get in touch",
     "panel_caption": "Interface preview — illustrative data",
     "panel": {
@@ -36,6 +36,11 @@
       "doc_delivery": "Delivery note",
       "status_done": "Processed",
       "status_review": "Awaiting review"
+    },
+    "rotator": {
+      "item_1": "Extracts amounts, tax IDs, and due dates from invoices.",
+      "item_2": "Answers questions based on your internal documents.",
+      "item_3": "Runs repeatable tasks based on rules you set."
     }
   }
 }

--- a/i18n/locales/sk.json
+++ b/i18n/locales/sk.json
@@ -27,8 +27,8 @@
     "gdpr_link": "Ochrana osobných údajov a cookies"
   },
   "hero": {
-    "title": "Faktúry a doklady prepíše za vás softvér, nie účtovníčka.",
-    "lead": "Nahráte alebo odfotíte doklad, systém vyťaží sumy, dodávateľa aj dátum splatnosti. Vy už len skontrolujete a schválite zápis do účtovníctva.",
+    "title": "Faktúru odfotíte, systém ju prečíta a založí v účtovníctve.",
+    "lead": "Vyťaží sumu, dodávateľa, IČO aj dátum splatnosti — vy si len overíte výsledok a kliknete na schválenie. Funguje to s faktúrami z e-mailu, naskenovanými aj odfotenými mobilom.",
     "cta_contact": "Napísať nám",
     "panel_caption": "Ukážka rozhrania — ilustračné dáta",
     "panel": {
@@ -36,6 +36,11 @@
       "doc_delivery": "Dodací list",
       "status_done": "Spracované",
       "status_review": "Čaká na kontrolu"
+    },
+    "rotator": {
+      "item_1": "Vyťaží sumy, IČO a splatnosť z faktúr.",
+      "item_2": "Odpovedá na otázky podľa vašich interných dokumentov.",
+      "item_3": "Spúšťa opakované úlohy podľa pravidiel, ktoré nastavíte."
     }
   }
 }


### PR DESCRIPTION
## Summary
Follow-up na issue #3 — Jurgo nebol spokojný s pôvodným hero textom (znel príliš generický/AI-marketingovo, lebo h1 bol takmer doslovne príkladová fráza zo spec časti 2).

- Nový h1/lead pomenúva konkrétny mechanizmus: odfotíte faktúru → systém ju prečíta → založí v účtovníctve, s konkrétnymi vstupnými kanálmi (e-mail, sken, mobil)
- Pridaný rotujúci riadok pod hero textom — cyklí cez 3 konkrétne schopnosti naviazané na produkty zo spec časti 4 (vyťažovanie dokladov / RAG / AI agenti), nie abstraktné benefity
- `<h1>` ostáva statický (SEO) — rotuje sa len doplnkový riadok pod ním
- `aria-live="polite"` namiesto úplného skrytia (na rozdiel od ilustračného panelu, ktorý je `aria-hidden`, keďže rotator nesie unikátnu informáciu)
- rotácia sa vôbec nespúšťa pri `prefers-reduced-motion: reduce`, navyše globálny CSS override v `main.css` skráti aj fade transition na minimum ako druhá poistka
- pauza rotácie pri hoveri

## Test plan
- [x] `npm run generate` bez chýb, nový text sa zobrazuje vo všetkých 3 jazykoch
- [x] `aria-live="polite"` prítomný v generovanom HTML
- [x] `npm run dev` beží bez runtime chýb
- [x] Jurgo: vizuálne overiť rotáciu v prehliadači a confirmovat finálny copy