### PR TITLE
5. Kontaktný formulár + Netlify Forms

### DIFF
--- a/app/components/ContactForm.vue
+++ b/app/components/ContactForm.vue
@@ -1,0 +1,261 @@
+<script setup lang="ts">
+const { t } = useI18n()
+
+const form = reactive({
+  name: '',
+  company: '',
+  email: '',
+  message: '',
+  consent: false,
+  botField: ''
+})
+
+const errors = reactive<{ name?: string; email?: string; message?: string; consent?: string }>({})
+const status = ref<'idle' | 'sending' | 'success' | 'error'>('idle')
+
+function isValidEmail(value: string) {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value.trim())
+}
+
+function validate() {
+  errors.name = form.name.trim() ? undefined : t('contact.error_required')
+  errors.email = isValidEmail(form.email) ? undefined : t('contact.error_email')
+  errors.message = form.message.trim() ? undefined : t('contact.error_required')
+  errors.consent = form.consent ? undefined : t('contact.error_consent')
+  return !errors.name && !errors.email && !errors.message && !errors.consent
+}
+
+async function onSubmit() {
+  if (form.botField) return
+
+  if (!validate()) return
+
+  status.value = 'sending'
+
+  const body = new URLSearchParams({
+    'form-name': 'contact',
+    name: form.name,
+    company: form.company,
+    email: form.email,
+    message: form.message
+  }).toString()
+
+  try {
+    const response = await fetch(window.location.pathname, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body
+    })
+
+    if (!response.ok) throw new Error('submit failed')
+    status.value = 'success'
+  } catch {
+    status.value = 'error'
+  }
+}
+</script>
+
+<template>
+  <section id="demo" class="contact">
+    <div class="contact__inner">
+      <h2>{{ t('contact.title') }}</h2>
+      <p class="contact__lead">{{ t('contact.lead') }}</p>
+
+      <form
+        name="contact"
+        method="POST"
+        data-netlify="true"
+        data-netlify-honeypot="bot-field"
+        novalidate
+        class="contact-form"
+        @submit.prevent="onSubmit"
+      >
+        <input type="hidden" name="form-name" value="contact" />
+
+        <p style="display: none">
+          <label>
+            Don't fill this out if you're human:
+            <input v-model="form.botField" name="bot-field" tabindex="-1" autocomplete="off" aria-hidden="true" />
+          </label>
+        </p>
+
+        <div v-if="status === 'success'" class="contact-form__success" role="status" aria-live="polite">
+          <h3>{{ t('contact.success_title') }}</h3>
+          <p>{{ t('contact.success_message') }}</p>
+        </div>
+
+        <template v-else>
+          <div class="contact-form__field">
+            <label for="cf-name">{{ t('contact.name_label') }}</label>
+            <input
+              id="cf-name"
+              v-model="form.name"
+              name="name"
+              type="text"
+              required
+              autocomplete="name"
+              :aria-invalid="!!errors.name"
+              :aria-describedby="errors.name ? 'cf-name-error' : undefined"
+            />
+            <p v-if="errors.name" id="cf-name-error" class="contact-form__error">{{ errors.name }}</p>
+          </div>
+
+          <div class="contact-form__field">
+            <label for="cf-company">{{ t('contact.company_label') }}</label>
+            <input id="cf-company" v-model="form.company" name="company" type="text" autocomplete="organization" />
+          </div>
+
+          <div class="contact-form__field">
+            <label for="cf-email">{{ t('contact.email_label') }}</label>
+            <input
+              id="cf-email"
+              v-model="form.email"
+              name="email"
+              type="email"
+              required
+              autocomplete="email"
+              :aria-invalid="!!errors.email"
+              :aria-describedby="errors.email ? 'cf-email-error' : undefined"
+            />
+            <p v-if="errors.email" id="cf-email-error" class="contact-form__error">{{ errors.email }}</p>
+          </div>
+
+          <div class="contact-form__field">
+            <label for="cf-message">{{ t('contact.message_label') }}</label>
+            <textarea
+              id="cf-message"
+              v-model="form.message"
+              name="message"
+              rows="4"
+              required
+              :placeholder="t('contact.message_placeholder')"
+              :aria-invalid="!!errors.message"
+              :aria-describedby="errors.message ? 'cf-message-error' : undefined"
+            ></textarea>
+            <p v-if="errors.message" id="cf-message-error" class="contact-form__error">{{ errors.message }}</p>
+          </div>
+
+          <div class="contact-form__field contact-form__field--checkbox">
+            <input
+              id="cf-consent"
+              v-model="form.consent"
+              name="consent"
+              type="checkbox"
+              :aria-invalid="!!errors.consent"
+              :aria-describedby="errors.consent ? 'cf-consent-error' : undefined"
+            />
+            <label for="cf-consent">
+              {{ t('contact.consent_pre') }}<a href="#">{{ t('contact.consent_link') }}</a>{{ t('contact.consent_post') }}
+            </label>
+            <p v-if="errors.consent" id="cf-consent-error" class="contact-form__error">{{ errors.consent }}</p>
+          </div>
+
+          <p v-if="status === 'error'" class="contact-form__error contact-form__error--generic" role="alert">
+            {{ t('contact.error_generic') }}
+          </p>
+
+          <button type="submit" class="btn-primary" :disabled="status === 'sending'">
+            {{ status === 'sending' ? t('contact.sending') : t('contact.submit') }}
+          </button>
+        </template>
+      </form>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.contact {
+  padding: 4rem 1.5rem;
+}
+
+.contact__inner {
+  max-width: 32rem;
+  margin: 0 auto;
+}
+
+.contact h2 {
+  font-size: clamp(1.6rem, 3vw, 2.1rem);
+  margin: 0 0 0.5rem;
+}
+
+.contact__lead {
+  margin: 0 0 2rem;
+  color: var(--color-text-muted);
+}
+
+.contact-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+}
+
+.contact-form__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.contact-form__field label {
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.contact-form__field input[type='text'],
+.contact-form__field input[type='email'],
+.contact-form__field textarea {
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 0.6rem 0.75rem;
+  color: var(--color-text);
+  font-size: 0.95rem;
+  font-family: inherit;
+}
+
+.contact-form__field input[aria-invalid='true'],
+.contact-form__field textarea[aria-invalid='true'] {
+  border-color: #e5484d;
+}
+
+.contact-form__field--checkbox {
+  flex-direction: row;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.contact-form__field--checkbox label {
+  font-weight: 400;
+  font-size: 0.85rem;
+}
+
+.contact-form__error {
+  margin: 0;
+  color: #e5484d;
+  font-size: 0.8rem;
+}
+
+.contact-form__error--generic {
+  font-size: 0.9rem;
+}
+
+.contact-form__success h3 {
+  margin: 0 0 0.5rem;
+}
+
+.contact-form__success p {
+  margin: 0;
+  color: var(--color-text-muted);
+}
+
+.contact-form button[type='submit'] {
+  align-self: flex-start;
+  border: none;
+  cursor: pointer;
+}
+
+.contact-form button[type='submit']:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+</style>

--- a/app/components/HeroSection.vue
+++ b/app/components/HeroSection.vue
@@ -50,7 +50,7 @@ onUnmounted(stopRotation)
         </p>
         <div class="hero__cta">
           <a href="#demo" class="btn-primary">{{ t('nav.cta_demo') }}</a>
-          <a href="#kontakt" class="btn-secondary">{{ t('hero.cta_contact') }}</a>
+          <a href="#demo" class="btn-secondary">{{ t('hero.cta_contact') }}</a>
         </div>
       </div>
 

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -15,5 +15,5 @@ useSeoMeta({
   <Testimonials />
   <FaqSection />
   <CtaBand />
-  <!-- TODO: kontaktný formulár pridaný v issue #5 -->
+  <ContactForm />
 </template>

--- a/i18n/locales/cs.json
+++ b/i18n/locales/cs.json
@@ -98,5 +98,25 @@
   },
   "cta_band": {
     "title": "Ukážeme vám to na vaší faktuře."
+  },
+  "contact": {
+    "title": "Ozvěte se nám",
+    "lead": "Napište nám pár slov o tom, co řešíte — ozveme se vám s termínem na krátké demo.",
+    "name_label": "Jméno a příjmení",
+    "company_label": "Firma",
+    "email_label": "E-mail",
+    "message_label": "Zpráva",
+    "message_placeholder": "Co byste chtěli automatizovat?",
+    "consent_pre": "Souhlasím se ",
+    "consent_link": "zpracováním osobních údajů",
+    "consent_post": ".",
+    "submit": "Odeslat",
+    "sending": "Odesílám…",
+    "success_title": "Děkujeme!",
+    "success_message": "Ozveme se vám co nejdříve na uvedený e-mail.",
+    "error_required": "Toto pole je povinné.",
+    "error_email": "Zadejte platný e-mail.",
+    "error_consent": "Pro odeslání je potřeba souhlas se zpracováním údajů.",
+    "error_generic": "Zprávu se nepodařilo odeslat. Zkuste to prosím znovu nebo nám napište na info{'@'}projentiq.com."
   }
 }

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -98,5 +98,25 @@
   },
   "cta_band": {
     "title": "We'll show you on your own invoice."
+  },
+  "contact": {
+    "title": "Get in touch",
+    "lead": "Tell us a bit about what you're looking to automate — we'll get back to you with a time for a short demo.",
+    "name_label": "Full name",
+    "company_label": "Company",
+    "email_label": "Email",
+    "message_label": "Message",
+    "message_placeholder": "What would you like to automate?",
+    "consent_pre": "I agree to the ",
+    "consent_link": "processing of personal data",
+    "consent_post": ".",
+    "submit": "Send",
+    "sending": "Sending…",
+    "success_title": "Thank you!",
+    "success_message": "We'll get back to you at the email you provided as soon as possible.",
+    "error_required": "This field is required.",
+    "error_email": "Enter a valid email address.",
+    "error_consent": "You need to agree to data processing before sending.",
+    "error_generic": "We couldn't send your message. Please try again or email us at info{'@'}projentiq.com."
   }
 }

--- a/i18n/locales/sk.json
+++ b/i18n/locales/sk.json
@@ -98,5 +98,25 @@
   },
   "cta_band": {
     "title": "Ukážeme vám to na vašej faktúre."
+  },
+  "contact": {
+    "title": "Ozvite sa nám",
+    "lead": "Napíšte nám pár slov o tom, čo riešite — ozveme sa vám s termínom na krátke demo.",
+    "name_label": "Meno a priezvisko",
+    "company_label": "Firma",
+    "email_label": "E-mail",
+    "message_label": "Správa",
+    "message_placeholder": "Čo by ste chceli automatizovať?",
+    "consent_pre": "Súhlasím so ",
+    "consent_link": "spracovaním osobných údajov",
+    "consent_post": ".",
+    "submit": "Odoslať",
+    "sending": "Odosielam…",
+    "success_title": "Ďakujeme!",
+    "success_message": "Ozveme sa vám čo najskôr na uvedený e-mail.",
+    "error_required": "Toto pole je povinné.",
+    "error_email": "Zadajte platný e-mail.",
+    "error_consent": "Pre odoslanie je potrebný súhlas so spracovaním údajov.",
+    "error_generic": "Správu sa nepodarilo odoslať. Skúste to prosím znova alebo nám napíšte na info{'@'}projentiq.com."
   }
 }


### PR DESCRIPTION
## Summary
- `ContactForm.vue` — meno, firma, e-mail, správa, GDPR checkbox (nepredvyplnený, link na zásady spracovania — placeholder `#`, stránka príde neskôr)
- **Netlify Forms gotcha overený priamo** (spec časť 7 poznámka): `data-netlify="true"`, hidden `form-name` input a honeypot (`data-netlify-honeypot` + skryté `bot-field`) som skontroloval priamo vo vygenerovanom statickom `npm run generate` HTML, nielen v dev móde — Netlify ich pri deployi nájde
- Klientská validácia (required, formát e-mailu, GDPR súhlas) s lokalizovanými chybami, `aria-invalid`/`aria-describedby`, `novalidate` na formulári (aby sa nepoužili nelokalizované natívne browser hlášky)
- AJAX submit cez `fetch(window.location.pathname, ...)` — funguje na sk/cs/en routách rovnako; stavy idle/sending/success/error, potvrdenie cez `aria-live="polite"`
- Opravené nekonzistentné CTA — hero aj header teraz mieria na `#demo` (predtým hero sekundárne CTA mierilo na `#kontakt`, ktorý nikam neviedol)
- Drobný fix: `@` v e-mailovej adrese v chybovej hláške bolo treba escapnúť (`{'@'}`) — vue-i18n ho inak parsuje ako linked-message syntax a build padal

## Test plan
- [x] `npm run generate` bez chýb pre sk/cs/en
- [x] `data-netlify`, `form-name` hidden input, honeypot prítomné v `.output/public/index.html` (a cs/en variantoch)
- [x] `npm run dev` beží bez runtime chýb
- [x] Jurgo: po deployi na Netlify reálne odoslať formulár a overiť, že sa submission objaví v Netlify dashboarde (Forms tab) — lokálne sa to overiť nedá, Netlify forms beží len na ich infraštruktúre
- [x] Jurgo: vizuálne overiť validáciu (prázdne polia, zlý e-mail, bez súhlasu) a úspešný/chybový stav v prehliadači

Closes #5