### PR TITLE
Implementácia copy spec — nové texty naprieč stránkou

### DIFF
--- a/.claude/projentiq_copy_SPEC.md
+++ b/.claude/projentiq_copy_SPEC.md
@@ -1,0 +1,223 @@
+# Spec: ProjentIQ — texty na web (copywriting & messaging)
+
+> Návod na všetky texty landing page. Píš podľa neho copy, ktoré predáva a neznie
+> ako AI marketing. Obsahuje stratégiu, tón, hotové drafty po sekciách, SEO a
+> microcopy. Drafty sú VÝCHODISKO — finál doladí Jurgo podľa reálnych faktov.
+
+---
+
+## 1. Jedna myšlienka, ktorú musí stránka odovzdať
+
+Ak si návštevník zapamätá jedinú vec, nech je to:
+
+> **„Doklady za nás prepíše softvér. My ich už len schválime."**
+
+Všetko ostatné (RAG, agenti, technológia) je podpora tejto jednej úľavy. Nepredávame
+AI. Predávame koniec ručného prepisovania a hľadania v dokumentoch.
+
+---
+
+## 2. Komu píšeme (a v akom rozpoložení)
+
+- **Kto:** majiteľ / konateľ / finančný alebo prevádzkový človek v malej až strednej
+  SK/CZ firme (10–150 ľudí). Často nie technik.
+- **Čo ho štve:** niekto v tíme trávi hodiny prepisovaním faktúr, dohľadávaním zmlúv,
+  odpovedaním na tie isté otázky. Vie, že je to plytvanie, ale myslí si, že
+  automatizácia je drahá / pre veľké firmy / komplikovaná.
+- **Úroveň uvedomenia:** pozná BOLESŤ, ale NEVIE, že riešenie je dostupné aj preňho.
+  → Úloha textu: pomenovať bolesť konkrétne → ukázať, aké je to jednoduché →
+  zbaviť riziko (demo na ich dátach, dáta v EÚ) → spraviť ďalší krok malým.
+- **Hlavné námietky (musíme ich v texte rozpustiť):**
+  1. „Je to bezpečné? Sú to naše finančné dáta."
+  2. „Bude to fungovať s naším účtovníctvom?"
+  3. „Čo ak sa to pomýli?"
+  4. „Ste malá neznáma firma — prečo vám veriť?"
+  5. „Koľko to stojí a oplatí sa to nám?"
+
+---
+
+## 3. Tón hlasu
+
+Píš ako kompetentný špecialista, ktorý vec pokojne vysvetľuje — nie ako predajca,
+ktorý kričí.
+
+**Áno:**
+- Krátke, konkrétne vety. Slovenčina prirodzená, nie preložená z angličtiny.
+- Vykáme („vy", „vaše doklady").
+- Hovor o výsledku a o tom, čo z toho má klient, nie o funkciách.
+- Pokoj a istota. Žiadne výkričníky.
+- Jeden konkrétny príklad > tri abstraktné výhody.
+
+**Nie (zakázané — toto je presne ten „AI marketing", ktorý nechceme):**
+- „revolučné", „inovatívne", „riešenie na mieru" (ako vata), „špičkové",
+  „najlepšie", „posuňte sa na ďalší level", „v dnešnej dobe", „transformácia",
+  „synergia", „cutting-edge", „a oveľa viac!"
+- trojice prídavných mien („rýchle, spoľahlivé a bezpečné")
+- vymyslené čísla a štatistiky, kým nie sú reálne (žiadne „80 %", „4 hodiny denne")
+- emoji v nadpisoch, výkričníky, superlatívy, ktoré sa nedajú dokázať
+
+**Test pred odoslaním každej vety:** Povedal by som to takto kolegovi pri káve?
+Ak to znie ako brožúra, prepíš.
+
+---
+
+## 4. Slovník
+
+- **Používaj:** prepisovať, doklad, faktúra, bloček, schváliť, skontrolovať,
+  ušetriť čas, napojenie, vaše dáta, ukážeme vám, jednoducho, bez prepisovania.
+- **Vyhýbaj sa:** vata slová z časti 3, anglicizmy bez potreby (radšej „napojenie"
+  než „integrácia", ak sa dá; „vyťažovanie údajov" než „data extraction").
+
+---
+
+## 5. Texty po sekciách (úloha + draft)
+
+### Hero
+**Úloha:** za 5 sekúnd musí návštevník vedieť „toto je pre mňa" a čo z toho má.
+Pomenuj bolesť, sľúb úľavu, ber strach (kontrola ostáva u neho), daj CTA.
+
+Nadpis (`<h1>`) — vyber/otestuj jednu z týchto, zoradené podľa môjho odporúčania:
+1. **„Doklady prepíše softvér, nie váš človek."** ← úľava + úspora drahého času
+2. „Z faktúry do účtovníctva bez ručného prepisovania." ← konkrétne, opisné
+3. „Účtovné doklady spracované za vás. Vy len schválite." ← úľava + kontrola
+4. „Prestaňte prepisovať faktúry ručne." ← priamy, pre problem-aware čitateľa
+
+Podnadpis (draft):
+> „Nahráte alebo odfotíte doklad, ProjentIQ z neho vytiahne údaje a pripraví ich
+> do vášho účtovníctva. Vy ich už len skontrolujete a schválite. Vaše dáta pritom
+> zostávajú u vás, v EÚ."
+
+CTA tlačidlá: **„Požiadať o demo"** (primárne) · **„Napísať nám"** (sekundárne).
+
+### Trust strip (pod hero)
+**Úloha:** okamžitá dôveryhodnosť cez konkrétnosť — dokáž, že rozumieš ICH svetu.
+Krátke štítky, nie vety: `Pohoda · Omega · iDoklad` · `eKasa QR pre bločky` ·
+`Dáta v EÚ` · `Slovenčina` · `Demo do 2 týždňov`.
+> Pozn.: konkrétne názvy (Pohoda, eKasa) sú silnejší dôkaz dôveryhodnosti než
+> akýkoľvek superlatív. Špecifickosť = dôvera.
+
+### Ako to funguje (4 kroky)
+**Úloha:** zabiť strach z komplikovanosti a zo straty kontroly. Ukáž, že je to
+jednoduché a že človek vždy schvaľuje.
+Draft krokov (názov + 1 veta):
+1. **Nahráte doklad** — PDF, sken alebo fotka z mobilu, aj viac naraz.
+2. **Systém vyťaží údaje** — dodávateľ, sumy, DPH, splatnosť aj položky.
+3. **Skontrolujete návrh** — sporné polia sú zvýraznené, opravíte ich klikom.
+4. **Zápis do účtovníctva** — údaje idú do Pohody, Omegy alebo vášho systému.
+
+### Produkty (3 karty)
+**Úloha:** ukáž cestu — začni tým, čo najviac brzdí, zvyšok pridáš neskôr.
+Každá karta: názov · 1 veta čo to je a čo z toho klient má · „od X €".
+Drafty:
+- **Vyťažovanie dokladov** — „Faktúry, bločky a dodacie listy automaticky do
+  účtovníctva. Vy len schválite." · od 2 000 €
+- **RAG znalostná báza** — „Opýtajte sa svojich dokumentov a dostanete odpoveď —
+  vždy s citáciou zdroja." · od 4 000 €
+- **AI agenti & automatizácia** — „E-mailoví agenti, schvaľovania a napojenie na
+  CRM či interné systémy." · od 8 000 €
+> Ceny sú placeholder na ladenie. Slovo „od" je dôležité — kotví a neuzatvára.
+
+### Prečo ProjentIQ
+**Úloha:** rozpusti námietku „prečo práve vy, malá neznáma firma". Odpoveď nie je
+„sme najlepší", ale konkrétne dôvody veriť:
+- **Dáta zostávajú u vás** — spracovanie v EÚ, žiadne zdieľanie s tretími stranami.
+- **Napojenie na slovenské systémy** — Pohoda, Omega, iDoklad a ďalšie.
+- **Naozajstná slovenčina** — ladené na slovenské doklady, diakritiku a jazyk.
+- **Demo na vašich dátach** — pred objednávkou uvidíte výsledok, nie sľub.
+
+### Referencie
+**Úloha:** zatiaľ nemáme klientov — z toho spravíme dôveru, nie slabinu.
+Draft: nadpis „Prvé nasadenia pripravujeme" + veta „Žiadne vymyslené citáty —
+sekciu naplníme po prvých reálnych nasadeniach." Čestnosť tu buduje dôveru.
+NIKDY nevymýšľaj referencie ani logá firiem.
+
+### FAQ
+**Úloha:** zabiť 4 najväčšie námietky priamo. Otázky aj odpovede vecné a krátke.
+Drafty:
+- **Ako sú chránené naše dáta?** — „Spracovanie prebieha v rámci EÚ a vaše
+  dokumenty nezdieľame s tretími stranami. Pri citlivých prevádzkach vieme
+  riešenie nasadiť priamo na vašu infraštruktúru."
+- **Na aké účtovné systémy sa napájate?** — „Pohoda, Omega, iDoklad a ďalšie cez
+  API alebo import. Vlastný systém prispôsobíme."
+- **Koľko trvá nasadenie?** — „Prvé funkčné demo na vašich dátach zvyčajne do dvoch
+  týždňov. Plné nasadenie závisí od rozsahu."
+- **Čo ak doklad nerozpozná správne?** — „Sporné polia sú vždy zvýraznené na
+  kontrolu a nič sa nezapíše bez vášho schválenia. Systém sa navyše učí z vašich
+  opráv."
+
+### Záverečný CTA band
+**Úloha:** ponúkni ďalší krok bez rizika.
+Draft: nadpis **„Ukážeme vám to na vašej faktúre."** + veta „Bezplatná konzultácia
+a demo na reálnom doklade z vašej firmy." + tlačidlá Požiadať o demo · Napísať nám.
+
+### Footer
+**Úloha:** legitimita. Názov firmy, IČO/sídlo (doplniť), kontakt, odkaz na ochranu
+údajov. Krátky popis: „AI automatizácia spracovania dokladov, znalostných báz a
+procesov pre malé a stredné firmy na Slovensku a v Česku."
+
+---
+
+## 6. Mapa námietok → kde ich riešime
+- Bezpečnosť dát → Prečo (EÚ) + FAQ (ochrana dát)
+- Kompatibilita s účtovníctvom → Trust strip + FAQ (Pohoda/Omega/iDoklad)
+- Chybovosť → Ako to funguje (krok 3) + FAQ
+- Malá neznáma firma → Demo na reálnych dátach + konkrétnosť všade
+- Cena / návratnosť → Produkty („od") + bezplatné demo
+
+---
+
+## 7. CTA & microcopy
+- **Primárne CTA všade rovnaké:** „Požiadať o demo". Konzistencia > kreativita.
+- Sekundárne: „Napísať nám".
+- Formulár — polia: Meno · Firma · E-mail · Správa (voliteľná). Nič citlivé.
+- Label nad poľom, nie placeholder namiesto labelu (prístupnosť).
+- Tlačidlo formulára: „Odoslať žiadosť o demo".
+- GDPR súhlas (nepredvyplnený checkbox): „Súhlasím so spracovaním údajov za účelom
+  odpovede na moju žiadosť. [Ochrana údajov]".
+- Po odoslaní: „Ďakujeme, ozveme sa do jedného pracovného dňa."
+- Chyba: „Niečo sa pokazilo. Skúste to znova alebo nám napíšte na [e-mail]."
+
+---
+
+## 8. SEO copy (vplietať prirodzene, nie napchávať)
+
+Kľúčové frázy, na ktoré píšeme (slovenské, ako ich ľudia reálne hľadajú):
+`vyťažovanie faktúr`, `spracovanie dokladov`, `automatizácia účtovníctva`,
+`vyťažovanie údajov z faktúr`, `AI pre firmy`, `spracovanie faktúr Pohoda`,
+`RAG znalostná báza`.
+
+- Použi hlavnú frázu v `<h1>` alebo prvom odseku prirodzene — nie násilne.
+- Každá `<h2>` nech obsahuje tému sekcie ľudskou rečou (Google aj človek).
+- **Meta title** (~55 znakov): `ProjentIQ — Vyťažovanie faktúr a dokladov pre firmy`
+- **Meta description** (~150 znakov): „Automaticky vyťažíme údaje z faktúr a dokladov
+  do vášho účtovníctva. Napojenie na Pohodu a Omegu, dáta zostávajú v EÚ. Ukážeme
+  vám to na vašej faktúre."
+- Žiadne keyword stuffing. Keď si vyberáš medzi SEO frázou a prirodzenou vetou,
+  vyhráva prirodzená veta.
+
+---
+
+## 9. Ako budovať dôveru bez referencií (dôležité)
+
+Nemáme klientov ani čísla. Dôveru teda staviame inak:
+- **Konkrétnosťou.** Spomenutie „eKasa QR", „DPH", „Pohoda" dokazuje, že rozumieme
+  ich svetu, lepšie než akýkoľvek superlatív.
+- **Risk reversal.** „Ukážeme vám to na vašej faktúre" — klient nič neriskuje.
+- **Transparentnosťou.** Čestný placeholder pri referenciách pôsobí dôveryhodnejšie
+  než vymyslené citáty.
+- **Mechanizmom, nie sľubmi.** „Vy len schválite" je dôveryhodnejšie než „ušetríte
+  80 %".
+> Keď raz budú reálne výsledky, doplň konkrétne čísla od konkrétneho klienta
+> (s jeho súhlasom). Dovtedy nič nevymýšľaj.
+
+---
+
+## 10. Záverečný checklist (pred publikovaním textu)
+- [ ] Žiadne vymyslené číslo, referencia ani logo.
+- [ ] Žiadne zakázané slovo z časti 3.
+- [ ] Každá sekcia hovorí o výsledku pre klienta, nie o funkcii.
+- [ ] Jeden `<h1>`, zmysluplné `<h2>`.
+- [ ] Hlavná SEO fráza prirodzene v hero/prvom odseku.
+- [ ] Meta title a description vyplnené.
+- [ ] CTA „Požiadať o demo" konzistentné všade.
+- [ ] Vety prešli testom „povedal by som to kolegovi pri káve?".

--- a/app/components/AppFooter.vue
+++ b/app/components/AppFooter.vue
@@ -8,6 +8,7 @@ const year = new Date().getFullYear()
     <div class="site-footer__inner">
       <div class="site-footer__brand">
         <strong>ProjentIQ</strong>
+        <p class="site-footer__tagline">{{ t('footer.tagline') }}</p>
         <!-- TODO: doplniť reálne sídlo a IČO -->
         <p>{{ t('footer.address_placeholder') }}</p>
         <p>{{ t('footer.ico_placeholder') }}</p>
@@ -45,6 +46,11 @@ const year = new Date().getFullYear()
 
 .site-footer__brand p {
   margin: 0.25rem 0;
+}
+
+.site-footer__brand .site-footer__tagline {
+  max-width: 24rem;
+  margin-top: 0.5rem;
 }
 
 .site-footer__links {

--- a/app/components/ContactForm.vue
+++ b/app/components/ContactForm.vue
@@ -10,7 +10,7 @@ const form = reactive({
   botField: ''
 })
 
-const errors = reactive<{ name?: string; email?: string; message?: string; consent?: string }>({})
+const errors = reactive<{ name?: string; email?: string; consent?: string }>({})
 const status = ref<'idle' | 'sending' | 'success' | 'error'>('idle')
 
 function isValidEmail(value: string) {
@@ -20,9 +20,8 @@ function isValidEmail(value: string) {
 function validate() {
   errors.name = form.name.trim() ? undefined : t('contact.error_required')
   errors.email = isValidEmail(form.email) ? undefined : t('contact.error_email')
-  errors.message = form.message.trim() ? undefined : t('contact.error_required')
   errors.consent = form.consent ? undefined : t('contact.error_consent')
-  return !errors.name && !errors.email && !errors.message && !errors.consent
+  return !errors.name && !errors.email && !errors.consent
 }
 
 async function onSubmit() {
@@ -127,12 +126,8 @@ async function onSubmit() {
               v-model="form.message"
               name="message"
               rows="4"
-              required
               :placeholder="t('contact.message_placeholder')"
-              :aria-invalid="!!errors.message"
-              :aria-describedby="errors.message ? 'cf-message-error' : undefined"
             ></textarea>
-            <p v-if="errors.message" id="cf-message-error" class="contact-form__error">{{ errors.message }}</p>
           </div>
 
           <div class="contact-form__field contact-form__field--checkbox">

--- a/app/components/CtaBand.vue
+++ b/app/components/CtaBand.vue
@@ -5,8 +5,14 @@ const { t } = useI18n()
 <template>
   <section class="cta-band">
     <div class="cta-band__inner">
-      <h2>{{ t('cta_band.title') }}</h2>
-      <a href="#demo" class="btn-primary">{{ t('nav.cta_demo') }}</a>
+      <div class="cta-band__copy">
+        <h2>{{ t('cta_band.title') }}</h2>
+        <p>{{ t('cta_band.lead') }}</p>
+      </div>
+      <div class="cta-band__actions">
+        <a href="#demo" class="btn-primary">{{ t('nav.cta_demo') }}</a>
+        <a href="#demo" class="btn-secondary">{{ t('hero.cta_contact') }}</a>
+      </div>
     </div>
   </section>
 </template>
@@ -29,8 +35,23 @@ const { t } = useI18n()
   gap: 1.5rem;
 }
 
+.cta-band__copy {
+  max-width: 36rem;
+}
+
 .cta-band h2 {
-  margin: 0;
+  margin: 0 0 0.4rem;
   font-size: clamp(1.4rem, 2.6vw, 1.8rem);
+}
+
+.cta-band__copy p {
+  margin: 0;
+  color: var(--color-text-muted);
+}
+
+.cta-band__actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
 }
 </style>

--- a/app/components/FaqSection.vue
+++ b/app/components/FaqSection.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 const { t } = useI18n()
 
-const items = [1, 2, 3, 4, 5]
+const items = [1, 2, 3, 4]
 </script>
 
 <template>

--- a/app/components/ProductCards.vue
+++ b/app/components/ProductCards.vue
@@ -1,12 +1,18 @@
 <script setup lang="ts">
-const { t } = useI18n()
+const { t, locale } = useI18n()
 
-// TODO: placeholder ceny na ladenie (spec časť 4, bod 4) — potvrdiť reálne
-// sumy aj menu pre CS trh (€ vs Kč) pred spustením.
+const localeMap: Record<string, string> = { sk: 'sk-SK', cs: 'cs-CZ', en: 'en-US' }
+
+function formatPrice(value: number) {
+  return value.toLocaleString(localeMap[locale.value] ?? 'sk-SK')
+}
+
+// TODO: placeholder jednorazové ceny za nasadenie (copy spec časť 5) —
+// potvrdiť reálne sumy aj menu pre CS trh (€ vs Kč) pred spustením.
 const cards = [
-  { id: 1, flagship: true, price: 49 },
-  { id: 2, flagship: false, price: 79 },
-  { id: 3, flagship: false, price: 99 }
+  { id: 1, flagship: true, price: 2000 },
+  { id: 2, flagship: false, price: 4000 },
+  { id: 3, flagship: false, price: 8000 }
 ]
 </script>
 
@@ -25,9 +31,8 @@ const cards = [
           <p v-if="card.flagship" class="products__badge">{{ t('products.flagship_badge') }}</p>
           <h3>{{ t(`products.card_${card.id}_title`) }}</h3>
           <p class="products__desc">{{ t(`products.card_${card.id}_desc`) }}</p>
-          <p class="products__for">{{ t(`products.card_${card.id}_for`) }}</p>
           <p class="products__price">
-            {{ t('products.price_from') }} <strong>{{ card.price }}</strong> {{ t('products.price_unit') }}
+            {{ t('products.price_from') }} <strong>{{ formatPrice(card.price) }} {{ t('products.price_currency') }}</strong>
           </p>
         </article>
       </div>
@@ -90,12 +95,6 @@ const cards = [
 .products__desc {
   margin: 0 0 0.75rem;
   font-size: 0.92rem;
-}
-
-.products__for {
-  margin: 0 0 1.25rem;
-  color: var(--color-text-muted);
-  font-size: 0.85rem;
 }
 
 .products__price {

--- a/app/components/Testimonials.vue
+++ b/app/components/Testimonials.vue
@@ -17,7 +17,7 @@ const testimonials: Testimonial[] = []
 <template>
   <section id="references" class="testimonials">
     <div class="testimonials__inner">
-      <h2>{{ t('nav.references') }}</h2>
+      <h2>{{ t('testimonials.title') }}</h2>
 
       <p v-if="testimonials.length === 0" class="testimonials__placeholder">
         {{ t('testimonials.coming_soon') }}

--- a/app/components/TrustStrip.vue
+++ b/app/components/TrustStrip.vue
@@ -1,4 +1,8 @@
 <script setup lang="ts">
+// TODO: trust_strip.item_2 (CS) hovorí len všeobecne "QR kód na účtenkách" —
+// SK verzia menuje konkrétny systém eKasa, pre CZ trh treba overiť s
+// marketérom, či existuje priamy ekvivalent na pomenovanie (napr. EET
+// nahradenie po roku 2023), aby štítok zostal rovnako konkrétny.
 const { t } = useI18n()
 
 const items = [1, 2, 3, 4, 5]

--- a/app/components/TrustStrip.vue
+++ b/app/components/TrustStrip.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+const { t } = useI18n()
+
+const items = [1, 2, 3, 4, 5]
+</script>
+
+<template>
+  <section class="trust-strip">
+    <ul class="trust-strip__list">
+      <li v-for="item in items" :key="item" class="trust-strip__item">
+        {{ t(`trust_strip.item_${item}`) }}
+      </li>
+    </ul>
+  </section>
+</template>
+
+<style scoped>
+.trust-strip {
+  padding: 1.5rem;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.trust-strip__list {
+  max-width: 72rem;
+  margin: 0 auto;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.75rem 2rem;
+}
+
+.trust-strip__item {
+  color: var(--color-text-muted);
+  font-size: 0.85rem;
+  font-weight: 600;
+  white-space: nowrap;
+}
+</style>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -9,6 +9,7 @@ useSeoMeta({
 
 <template>
   <HeroSection />
+  <TrustStrip />
   <HowItWorks />
   <ProductCards />
   <WhyProjentIQ />

--- a/i18n/locales/cs.json
+++ b/i18n/locales/cs.json
@@ -7,8 +7,8 @@
     "cta_demo": "Vyžádat demo"
   },
   "meta": {
-    "title": "ProjentIQ — AI automatizace faktur a dokumentů pro firmy",
-    "description": "AI automatizace zpracování faktur a dokumentů pro slovenské a české firmy."
+    "title": "ProjentIQ — Vytěžování faktur a dokladů pro firmy",
+    "description": "Automaticky vytěžíme údaje z faktur a dokladů do vašeho účetnictví. Napojení na Pohodu a Omegu, data zůstávají v EU. Ukážeme vám to na vaší faktuře."
   },
   "a11y": {
     "skip_link": "Přeskočit na obsah"
@@ -22,13 +22,14 @@
   },
   "footer": {
     "links_label": "Odkazy",
+    "tagline": "AI automatizace zpracování dokladů, znalostních bází a procesů pro malé a střední firmy na Slovensku a v Česku.",
     "address_placeholder": "Sídlo: TODO — doplnit skutečnou adresu",
     "ico_placeholder": "IČO: TODO — doplnit",
     "gdpr_link": "Ochrana osobních údajů a cookies"
   },
   "hero": {
-    "title": "Fakturu vyfotíte, systém ji přečte a založí v účetnictví.",
-    "lead": "Vytěží částku, dodavatele, IČO i datum splatnosti — vy si jen ověříte výsledek a kliknete na schválení. Funguje to s fakturami z e-mailu, naskenovanými i vyfocenými mobilem.",
+    "title": "Doklady přepíše software, ne váš člověk.",
+    "lead": "Nahrajete nebo vyfotíte doklad, ProjentIQ z něj vytáhne údaje a připraví je do vašeho účetnictví. Vy je už jen zkontrolujete a schválíte. Vaše data přitom zůstávají u vás, v EU.",
     "cta_contact": "Napsat nám",
     "panel_caption": "Ukázka rozhraní — ilustrační data",
     "panel": {
@@ -43,61 +44,65 @@
       "item_3": "Spouští opakované úkoly podle pravidel, která nastavíte."
     }
   },
+  "trust_strip": {
+    "item_1": "Pohoda · Omega · iDoklad",
+    "item_2": "QR kód na účtenkách",
+    "item_3": "Data v EU",
+    "item_4": "Čeština",
+    "item_5": "Demo do 2 týdnů"
+  },
   "how_it_works": {
     "title": "Jak to funguje",
     "step_1_title": "Nahrajete doklad",
-    "step_1_desc": "Pošlete fakturu e-mailem, naskenujete nebo vyfotíte mobilem.",
+    "step_1_desc": "PDF, sken nebo fotka z mobilu, klidně i víc najednou.",
     "step_2_title": "Systém vytěží údaje",
-    "step_2_desc": "Přečte částku, dodavatele, IČO i datum splatnosti.",
-    "step_3_title": "Vy zkontrolujete",
-    "step_3_desc": "Porovnáte výsledek s originálem, případně něco opravíte.",
-    "step_4_title": "Zapíše se do účetnictví",
-    "step_4_desc": "Schválený doklad se uloží přímo do vašeho systému."
+    "step_2_desc": "Dodavatele, částky, DPH, splatnost i položky.",
+    "step_3_title": "Zkontrolujete návrh",
+    "step_3_desc": "Sporná pole jsou zvýrazněná, opravíte je kliknutím.",
+    "step_4_title": "Zápis do účetnictví",
+    "step_4_desc": "Údaje jdou do Pohody, Omegy nebo vašeho systému."
   },
   "products": {
     "title": "Řešení a ceník",
     "price_from": "od",
-    "price_unit": "€ / měsíc",
+    "price_currency": "€",
     "flagship_badge": "Hlavní produkt",
     "card_1_title": "Vytěžování dokladů",
-    "card_1_desc": "Automaticky přečte a roztřídí faktury, dodací listy i účtenky do vašeho účetnictví.",
-    "card_1_for": "Pro firmy, které zpracovávají desítky až stovky dokladů měsíčně.",
+    "card_1_desc": "Faktury, účtenky a dodací listy automaticky do účetnictví. Vy jen schválíte.",
     "card_2_title": "RAG znalostní báze",
-    "card_2_desc": "Prohledává vaše interní dokumenty a odpovídá na otázky s odkazem na zdroj.",
-    "card_2_for": "Pro týmy, které ztrácí čas hledáním informací v dokumentaci.",
+    "card_2_desc": "Zeptejte se svých dokumentů a dostanete odpověď — vždy s citací zdroje.",
     "card_3_title": "AI agenti a automatizace",
-    "card_3_desc": "Spouští opakované úkoly podle pravidel, která nastavíte — bez manuálních kroků.",
-    "card_3_for": "Pro firmy s opakovanými procesy napříč systémy."
+    "card_3_desc": "E-mailoví agenti, schvalování a napojení na CRM či interní systémy."
   },
   "why": {
     "title": "Proč ProjentIQ",
     "item_1_title": "Data zůstávají u vás",
-    "item_1_desc": "Zpracování probíhá v EU, žádná data neopouští dohodnutou infrastrukturu.",
-    "item_2_title": "Napojení na vaše účetnictví",
-    "item_2_desc": "Podporujeme Pohodu, Omegu i iDoklad — bez ručního exportu a importu.",
-    "item_3_title": "Rozumí češtině i slovenštině",
-    "item_3_desc": "Není to překlad z angličtiny — systém je trénovaný na lokální doklady a jazyk.",
-    "item_4_title": "Demo na vašich dokladech",
-    "item_4_desc": "Před objednávkou vám ukážeme, jak systém zpracuje vaše reálné faktury."
+    "item_1_desc": "Zpracování v EU, žádné sdílení s třetími stranami.",
+    "item_2_title": "Napojení na české i slovenské systémy",
+    "item_2_desc": "Pohoda, Omega, iDoklad a další.",
+    "item_3_title": "Skutečná čeština a slovenština",
+    "item_3_desc": "Laděno na české i slovenské doklady, diakritiku a jazyk.",
+    "item_4_title": "Demo na vašich datech",
+    "item_4_desc": "Před objednávkou uvidíte výsledek, ne slib."
   },
   "testimonials": {
-    "coming_soon": "Zatím nemáme reference, které bychom mohli zveřejnit — pracujeme na tom s prvními klienty."
+    "title": "První nasazení připravujeme",
+    "coming_soon": "Žádné vymyšlené citace — sekci naplníme po prvních reálných nasazeních."
   },
   "faq": {
     "title": "Časté otázky",
     "q1": "Jak jsou chráněna naše data?",
-    "a1": "Data zpracováváme v EU a neopouští dohodnutou infrastrukturu. S každým klientem podepisujeme zpracovatelskou smlouvu podle GDPR.",
+    "a1": "Zpracování probíhá v rámci EU a vaše dokumenty nesdílíme s třetími stranami. U citlivých provozů umíme řešení nasadit přímo na vaši infrastrukturu.",
     "q2": "Na jaké účetní systémy se napojujete?",
-    "a2": "Aktuálně podporujeme Pohodu, Omegu a iDoklad. U jiných systémů umíme připravit napojení na míru — ozvěte se nám.",
+    "a2": "Pohoda, Omega, iDoklad a další přes API nebo import. Vlastní systém přizpůsobíme.",
     "q3": "Jak dlouho trvá nasazení?",
-    "a3": "Závisí na rozsahu a počtu typů dokladů, obvykle jde o dny až pár týdnů. Přesný odhad dostanete po první konzultaci.",
-    "q4": "Co když systém doklad nerozpozná správně?",
-    "a4": "Označíte chybu přímo při kontrole, opravíte hodnotu a systém si to zapamatuje pro budoucí podobné doklady.",
-    "q5": "Musíme měnit naše současné účetnictví?",
-    "a5": "Ne, systém se napojuje na váš existující systém, nenahrazuje ho."
+    "a3": "První funkční demo na vašich datech obvykle do dvou týdnů. Plné nasazení závisí na rozsahu.",
+    "q4": "Co když doklad nerozpozná správně?",
+    "a4": "Sporná pole jsou vždy zvýrazněná ke kontrole a nic se nezapíše bez vašeho schválení. Systém se navíc učí z vašich oprav."
   },
   "cta_band": {
-    "title": "Ukážeme vám to na vaší faktuře."
+    "title": "Ukážeme vám to na vaší faktuře.",
+    "lead": "Bezplatná konzultace a demo na reálném dokladu z vaší firmy."
   },
   "contact": {
     "title": "Ozvěte se nám",
@@ -105,18 +110,18 @@
     "name_label": "Jméno a příjmení",
     "company_label": "Firma",
     "email_label": "E-mail",
-    "message_label": "Zpráva",
+    "message_label": "Zpráva (nepovinná)",
     "message_placeholder": "Co byste chtěli automatizovat?",
-    "consent_pre": "Souhlasím se ",
-    "consent_link": "zpracováním osobních údajů",
-    "consent_post": ".",
-    "submit": "Odeslat",
+    "consent_pre": "Souhlasím se zpracováním údajů za účelem odpovědi na mou žádost. ",
+    "consent_link": "Ochrana údajů",
+    "consent_post": "",
+    "submit": "Odeslat žádost o demo",
     "sending": "Odesílám…",
     "success_title": "Děkujeme!",
-    "success_message": "Ozveme se vám co nejdříve na uvedený e-mail.",
+    "success_message": "Ozveme se vám do jednoho pracovního dne.",
     "error_required": "Toto pole je povinné.",
     "error_email": "Zadejte platný e-mail.",
     "error_consent": "Pro odeslání je potřeba souhlas se zpracováním údajů.",
-    "error_generic": "Zprávu se nepodařilo odeslat. Zkuste to prosím znovu nebo nám napište na info{'@'}projentiq.com."
+    "error_generic": "Něco se pokazilo. Zkuste to znovu nebo nám napište na info{'@'}projentiq.com."
   }
 }

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -7,8 +7,8 @@
     "cta_demo": "Request a demo"
   },
   "meta": {
-    "title": "ProjentIQ — AI invoice and document automation for businesses",
-    "description": "AI automation for invoice and document processing, built for Slovak and Czech businesses."
+    "title": "ProjentIQ — Invoice and document extraction for businesses",
+    "description": "We automatically extract data from your invoices and documents into your accounting system. Connects to Pohoda and Omega, data stays in the EU. We'll show you on your own invoice."
   },
   "a11y": {
     "skip_link": "Skip to content"
@@ -22,13 +22,14 @@
   },
   "footer": {
     "links_label": "Links",
+    "tagline": "AI automation for document processing, knowledge bases, and workflows — built for small and mid-sized businesses in Slovakia and Czechia.",
     "address_placeholder": "Registered address: TODO — add real address",
     "ico_placeholder": "Company ID: TODO — add real ID",
     "gdpr_link": "Privacy & cookies"
   },
   "hero": {
-    "title": "Photograph an invoice and the system reads it straight into your books.",
-    "lead": "It picks out the amount, vendor, tax ID, and due date — you just check the result and approve it. Works with invoices from email, scans, or a phone photo.",
+    "title": "Software processes your documents, not your staff.",
+    "lead": "Upload or photograph a document and ProjentIQ pulls out the data and prepares it for your accounting system. You just review and approve it. Your data stays with you, in the EU.",
     "cta_contact": "Get in touch",
     "panel_caption": "Interface preview — illustrative data",
     "panel": {
@@ -43,61 +44,65 @@
       "item_3": "Runs repeatable tasks based on rules you set."
     }
   },
+  "trust_strip": {
+    "item_1": "Pohoda · Omega · iDoklad",
+    "item_2": "eKasa QR receipts",
+    "item_3": "Data stored in the EU",
+    "item_4": "Slovak & Czech",
+    "item_5": "Demo within 2 weeks"
+  },
   "how_it_works": {
     "title": "How it works",
     "step_1_title": "Upload the document",
-    "step_1_desc": "Send an invoice by email, scan it, or take a photo with your phone.",
+    "step_1_desc": "A PDF, a scan, or a phone photo — upload several at once if you like.",
     "step_2_title": "The system extracts the data",
-    "step_2_desc": "It reads the amount, vendor, tax ID, and due date.",
-    "step_3_title": "You review it",
-    "step_3_desc": "Compare the result with the original and fix anything if needed.",
-    "step_4_title": "It's recorded in your accounting system",
-    "step_4_desc": "Once approved, the document is saved directly into your system."
+    "step_2_desc": "Vendor, amounts, VAT, due date, and line items.",
+    "step_3_title": "You review the draft",
+    "step_3_desc": "Flagged fields are highlighted — fix them with a click.",
+    "step_4_title": "Entry into your accounting system",
+    "step_4_desc": "Data goes into Pohoda, Omega, or your own system."
   },
   "products": {
     "title": "Solutions & pricing",
     "price_from": "from",
-    "price_unit": "€ / month",
+    "price_currency": "€",
     "flagship_badge": "Flagship product",
     "card_1_title": "Document extraction",
-    "card_1_desc": "Automatically reads and sorts invoices, delivery notes, and receipts into your accounting system.",
-    "card_1_for": "For businesses processing dozens to hundreds of documents a month.",
+    "card_1_desc": "Invoices, receipts, and delivery notes go straight into your accounting system. You just approve them.",
     "card_2_title": "RAG knowledge base",
-    "card_2_desc": "Searches your internal documents and answers questions with a source reference.",
-    "card_2_for": "For teams losing time searching through documentation.",
+    "card_2_desc": "Ask your documents a question and get an answer — always with a source citation.",
     "card_3_title": "AI agents & automation",
-    "card_3_desc": "Runs repeatable tasks based on rules you define — no manual steps.",
-    "card_3_for": "For businesses with repeatable processes across multiple systems."
+    "card_3_desc": "Email agents, approval flows, and connections to your CRM or internal systems."
   },
   "why": {
     "title": "Why ProjentIQ",
     "item_1_title": "Your data stays with you",
-    "item_1_desc": "Processing happens in the EU — no data leaves the agreed infrastructure.",
-    "item_2_title": "Connects to your accounting system",
-    "item_2_desc": "We support Pohoda, Omega, and iDoklad — no manual export or import.",
+    "item_1_desc": "Processing happens in the EU, with no sharing with third parties.",
+    "item_2_title": "Connects to Slovak and Czech systems",
+    "item_2_desc": "Pohoda, Omega, iDoklad, and more.",
     "item_3_title": "Built for Slovak and Czech",
-    "item_3_desc": "Not a translation from English — the system is trained on local documents and language.",
-    "item_4_title": "Demo on your own documents",
-    "item_4_desc": "Before you commit, we'll show you how the system handles your real invoices."
+    "item_3_desc": "Tuned for local documents, diacritics, and language.",
+    "item_4_title": "Demo on your own data",
+    "item_4_desc": "Before you commit, you'll see a result, not a promise."
   },
   "testimonials": {
-    "coming_soon": "We don't have publishable references yet — we're working on this with our first clients."
+    "title": "Our first deployments are underway",
+    "coming_soon": "No invented quotes — we'll fill this in once we have real deployments."
   },
   "faq": {
     "title": "Frequently asked questions",
     "q1": "How is our data protected?",
-    "a1": "Data is processed within the EU and doesn't leave the agreed infrastructure. We sign a data processing agreement under GDPR with every client.",
+    "a1": "Processing happens within the EU and we don't share your documents with third parties. For sensitive setups, we can deploy directly on your own infrastructure.",
     "q2": "Which accounting systems do you connect to?",
-    "a2": "We currently support Pohoda, Omega, and iDoklad. For other systems we can build a custom connection — get in touch.",
-    "q3": "How long does setup take?",
-    "a3": "It depends on the scope and number of document types, usually days to a few weeks. You'll get an exact estimate after the first consultation.",
+    "a2": "Pohoda, Omega, iDoklad, and others via API or import. We can adapt to your own system too.",
+    "q3": "How long does deployment take?",
+    "a3": "A first working demo on your own data usually takes up to two weeks. Full deployment depends on scope.",
     "q4": "What if the system misreads a document?",
-    "a4": "You flag the error right during review, correct the value, and the system remembers it for similar documents going forward.",
-    "q5": "Do we need to change our current accounting system?",
-    "a5": "No, the system connects to your existing setup — it doesn't replace it."
+    "a4": "Flagged fields are always highlighted for review, and nothing gets recorded without your approval. The system also learns from your corrections."
   },
   "cta_band": {
-    "title": "We'll show you on your own invoice."
+    "title": "We'll show you on your own invoice.",
+    "lead": "A free consultation and a demo on a real document from your company."
   },
   "contact": {
     "title": "Get in touch",
@@ -105,18 +110,18 @@
     "name_label": "Full name",
     "company_label": "Company",
     "email_label": "Email",
-    "message_label": "Message",
+    "message_label": "Message (optional)",
     "message_placeholder": "What would you like to automate?",
-    "consent_pre": "I agree to the ",
-    "consent_link": "processing of personal data",
-    "consent_post": ".",
-    "submit": "Send",
+    "consent_pre": "I agree to the processing of data for the purpose of responding to my request. ",
+    "consent_link": "Privacy policy",
+    "consent_post": "",
+    "submit": "Request a demo",
     "sending": "Sending…",
     "success_title": "Thank you!",
-    "success_message": "We'll get back to you at the email you provided as soon as possible.",
+    "success_message": "We'll get back to you within one business day.",
     "error_required": "This field is required.",
     "error_email": "Enter a valid email address.",
     "error_consent": "You need to agree to data processing before sending.",
-    "error_generic": "We couldn't send your message. Please try again or email us at info{'@'}projentiq.com."
+    "error_generic": "Something went wrong. Please try again or email us at info{'@'}projentiq.com."
   }
 }

--- a/i18n/locales/sk.json
+++ b/i18n/locales/sk.json
@@ -7,8 +7,8 @@
     "cta_demo": "Požiadať o demo"
   },
   "meta": {
-    "title": "ProjentIQ — AI automatizácia faktúr a dokumentov pre firmy",
-    "description": "AI automatizácia spracovania faktúr a dokumentov pre slovenské a české firmy."
+    "title": "ProjentIQ — Vyťažovanie faktúr a dokladov pre firmy",
+    "description": "Automaticky vyťažíme údaje z faktúr a dokladov do vášho účtovníctva. Napojenie na Pohodu a Omegu, dáta zostávajú v EÚ. Ukážeme vám to na vašej faktúre."
   },
   "a11y": {
     "skip_link": "Preskočiť na obsah"
@@ -22,13 +22,14 @@
   },
   "footer": {
     "links_label": "Odkazy",
+    "tagline": "AI automatizácia spracovania dokladov, znalostných báz a procesov pre malé a stredné firmy na Slovensku a v Česku.",
     "address_placeholder": "Sídlo: TODO — doplniť reálnu adresu",
     "ico_placeholder": "IČO: TODO — doplniť",
     "gdpr_link": "Ochrana osobných údajov a cookies"
   },
   "hero": {
-    "title": "Faktúru odfotíte, systém ju prečíta a založí v účtovníctve.",
-    "lead": "Vyťaží sumu, dodávateľa, IČO aj dátum splatnosti — vy si len overíte výsledok a kliknete na schválenie. Funguje to s faktúrami z e-mailu, naskenovanými aj odfotenými mobilom.",
+    "title": "Doklady prepíše softvér, nie váš človek.",
+    "lead": "Nahráte alebo odfotíte doklad, ProjentIQ z neho vytiahne údaje a pripraví ich do vášho účtovníctva. Vy ich už len skontrolujete a schválite. Vaše dáta pritom zostávajú u vás, v EÚ.",
     "cta_contact": "Napísať nám",
     "panel_caption": "Ukážka rozhrania — ilustračné dáta",
     "panel": {
@@ -43,61 +44,65 @@
       "item_3": "Spúšťa opakované úlohy podľa pravidiel, ktoré nastavíte."
     }
   },
+  "trust_strip": {
+    "item_1": "Pohoda · Omega · iDoklad",
+    "item_2": "eKasa QR pre bločky",
+    "item_3": "Dáta v EÚ",
+    "item_4": "Slovenčina",
+    "item_5": "Demo do 2 týždňov"
+  },
   "how_it_works": {
     "title": "Ako to funguje",
     "step_1_title": "Nahráte doklad",
-    "step_1_desc": "Pošlete faktúru e-mailom, naskenujete alebo odfotíte mobilom.",
+    "step_1_desc": "PDF, sken alebo fotka z mobilu, aj viac naraz.",
     "step_2_title": "Systém vyťaží údaje",
-    "step_2_desc": "Prečíta sumu, dodávateľa, IČO aj dátum splatnosti.",
-    "step_3_title": "Vy skontrolujete",
-    "step_3_desc": "Porovnáte výsledok s originálom, prípadne niečo opravíte.",
-    "step_4_title": "Zapíše sa do účtovníctva",
-    "step_4_desc": "Schválený doklad sa uloží priamo do vášho systému."
+    "step_2_desc": "Dodávateľ, sumy, DPH, splatnosť aj položky.",
+    "step_3_title": "Skontrolujete návrh",
+    "step_3_desc": "Sporné polia sú zvýraznené, opravíte ich klikom.",
+    "step_4_title": "Zápis do účtovníctva",
+    "step_4_desc": "Údaje idú do Pohody, Omegy alebo vášho systému."
   },
   "products": {
     "title": "Riešenia a ceny",
     "price_from": "od",
-    "price_unit": "€ / mesiac",
+    "price_currency": "€",
     "flagship_badge": "Hlavný produkt",
     "card_1_title": "Vyťažovanie dokladov",
-    "card_1_desc": "Automaticky prečíta a zatriedi faktúry, dodacie listy aj účtenky do vášho účtovníctva.",
-    "card_1_for": "Pre firmy, ktoré spracúvajú desiatky až stovky dokladov mesačne.",
+    "card_1_desc": "Faktúry, bločky a dodacie listy automaticky do účtovníctva. Vy len schválite.",
     "card_2_title": "RAG znalostná báza",
-    "card_2_desc": "Prehľadáva vaše interné dokumenty a odpovedá na otázky s odkazom na zdroj.",
-    "card_2_for": "Pre tímy, ktoré strácajú čas hľadaním informácií v dokumentácii.",
+    "card_2_desc": "Opýtajte sa svojich dokumentov a dostanete odpoveď — vždy s citáciou zdroja.",
     "card_3_title": "AI agenti & automatizácia",
-    "card_3_desc": "Spúšťa opakované úlohy podľa pravidiel, ktoré nastavíte — bez manuálnych krokov.",
-    "card_3_for": "Pre firmy s opakovanými procesmi naprieč systémami."
+    "card_3_desc": "E-mailoví agenti, schvaľovania a napojenie na CRM či interné systémy."
   },
   "why": {
     "title": "Prečo ProjentIQ",
     "item_1_title": "Dáta zostávajú u vás",
-    "item_1_desc": "Spracovanie prebieha v EÚ, žiadne dáta neopúšťajú dohodnutú infraštruktúru.",
-    "item_2_title": "Napojenie na vaše účtovníctvo",
-    "item_2_desc": "Podporujeme Pohodu, Omegu aj iDoklad — bez ručného exportu a importu.",
-    "item_3_title": "Rozumie slovenčine aj češtine",
-    "item_3_desc": "Nie je to preklad z angličtiny — systém je trénovaný na lokálne doklady a jazyk.",
-    "item_4_title": "Demo na vašich dokladoch",
-    "item_4_desc": "Pred objednávkou vám ukážeme, ako systém spracuje vaše reálne faktúry."
+    "item_1_desc": "Spracovanie v EÚ, žiadne zdieľanie s tretími stranami.",
+    "item_2_title": "Napojenie na slovenské systémy",
+    "item_2_desc": "Pohoda, Omega, iDoklad a ďalšie.",
+    "item_3_title": "Naozajstná slovenčina",
+    "item_3_desc": "Ladené na slovenské doklady, diakritiku a jazyk.",
+    "item_4_title": "Demo na vašich dátach",
+    "item_4_desc": "Pred objednávkou uvidíte výsledok, nie sľub."
   },
   "testimonials": {
-    "coming_soon": "Zatiaľ nemáme referencie, ktoré by sme mohli zverejniť — pracujeme na tom s prvými klientmi."
+    "title": "Prvé nasadenia pripravujeme",
+    "coming_soon": "Žiadne vymyslené citáty — sekciu naplníme po prvých reálnych nasadeniach."
   },
   "faq": {
     "title": "Časté otázky",
     "q1": "Ako sú chránené naše dáta?",
-    "a1": "Dáta spracúvame v EÚ a neopúšťajú dohodnutú infraštruktúru. S každým klientom podpisujeme spracovateľskú zmluvu podľa GDPR.",
+    "a1": "Spracovanie prebieha v rámci EÚ a vaše dokumenty nezdieľame s tretími stranami. Pri citlivých prevádzkach vieme riešenie nasadiť priamo na vašu infraštruktúru.",
     "q2": "Na aké účtovné systémy sa napájate?",
-    "a2": "Aktuálne podporujeme Pohodu, Omegu a iDoklad. Pri iných systémoch vieme pripraviť napojenie na mieru — ozvite sa nám.",
+    "a2": "Pohoda, Omega, iDoklad a ďalšie cez API alebo import. Vlastný systém prispôsobíme.",
     "q3": "Koľko trvá nasadenie?",
-    "a3": "Závisí od rozsahu a počtu dokladových typov, zvyčajne ide o dni až pár týždňov. Presný odhad dostanete po prvej konzultácii.",
-    "q4": "Čo ak doklad systém nerozpozná správne?",
-    "a4": "Označíte chybu priamo pri kontrole, opravíte hodnotu a systém si to zapamätá pre budúce podobné doklady.",
-    "q5": "Musíme meniť naše súčasné účtovníctvo?",
-    "a5": "Nie, systém sa napája na váš existujúci systém, nenahrádza ho."
+    "a3": "Prvé funkčné demo na vašich dátach zvyčajne do dvoch týždňov. Plné nasadenie závisí od rozsahu.",
+    "q4": "Čo ak doklad nerozpozná správne?",
+    "a4": "Sporné polia sú vždy zvýraznené na kontrolu a nič sa nezapíše bez vášho schválenia. Systém sa navyše učí z vašich opráv."
   },
   "cta_band": {
-    "title": "Ukážeme vám to na vašej faktúre."
+    "title": "Ukážeme vám to na vašej faktúre.",
+    "lead": "Bezplatná konzultácia a demo na reálnom doklade z vašej firmy."
   },
   "contact": {
     "title": "Ozvite sa nám",
@@ -105,18 +110,18 @@
     "name_label": "Meno a priezvisko",
     "company_label": "Firma",
     "email_label": "E-mail",
-    "message_label": "Správa",
+    "message_label": "Správa (voliteľná)",
     "message_placeholder": "Čo by ste chceli automatizovať?",
-    "consent_pre": "Súhlasím so ",
-    "consent_link": "spracovaním osobných údajov",
-    "consent_post": ".",
-    "submit": "Odoslať",
+    "consent_pre": "Súhlasím so spracovaním údajov za účelom odpovede na moju žiadosť. ",
+    "consent_link": "Ochrana údajov",
+    "consent_post": "",
+    "submit": "Odoslať žiadosť o demo",
     "sending": "Odosielam…",
     "success_title": "Ďakujeme!",
-    "success_message": "Ozveme sa vám čo najskôr na uvedený e-mail.",
+    "success_message": "Ozveme sa vám do jedného pracovného dňa.",
     "error_required": "Toto pole je povinné.",
     "error_email": "Zadajte platný e-mail.",
     "error_consent": "Pre odoslanie je potrebný súhlas so spracovaním údajov.",
-    "error_generic": "Správu sa nepodarilo odoslať. Skúste to prosím znova alebo nám napíšte na info{'@'}projentiq.com."
+    "error_generic": "Niečo sa pokazilo. Skúste to znova alebo nám napíšte na info{'@'}projentiq.com."
   }
 }


### PR DESCRIPTION
## Summary
Implementuje `.claude/projentiq_copy_SPEC.md` naprieč celou landing page (SK ako master, CS/EN prirodzene lokalizované — potvrdené s Jurgom).

- **Hero** — nový h1 (variant 1 z odporúčania spec), nový lead
- **Nová sekcia TrustStrip** — krátke štítky pod heroom (Pohoda/Omega/iDoklad, eKasa QR, dáta v EÚ, jazyk, demo do 2 týždňov)
- **Ako to funguje** — bohatší obsah krokov (DPH, položky, sporné polia)
- **Produkty** — nové popisy, **jednorazové** ceny 2 000/4 000/8 000 € (potvrdené, žiadna mesačná jednotka), zjednodušená karta (bez "pre koho" riadku), formátovanie cien teraz locale-aware (`toLocaleString` — SK/CS medzera, EN čiarka)
- **Prečo ProjentIQ** — preformulované
- **Referencie** — nový nadpis "Prvé nasadenia pripravujeme" + placeholder text
- **FAQ** — presne 4 otázky naviazané na 4 hlavné námietky (nahrádza pôvodných 5, potvrdené)
- **CTA band** — pridaný lead + sekundárne tlačidlo
- **Footer** — pridaný tagline pod menom značky
- **Kontaktný formulár** — správa je teraz voliteľná, nový text tlačidla/súhlasu/potvrdenia/chyby
- **SEO meta** title/description podľa spec časti 8

CS lokalizácia "why"/trust strip sekcie zámerne nekopíruje SK 1:1 — napr. zdôrazňuje aj češtinu (nielen slovenčinu), keďže ide o CZ čitateľa. Jeden flagnutý TODO v `TrustStrip.vue`: CZ ekvivalent pre "eKasa QR" nie je istý, treba overiť s marketérom.

## Test plan
- [x] Parita locale kľúčov: 91/91/91 (sk/cs/en)
- [x] `npm run generate` bez chýb
- [x] Nový h1, trust strip, ceny (2 000/4 000/8 000 €), 4× FAQ, footer tagline overené priamo vo vygenerovanom HTML pre všetky 3 jazyky
- [x] `npm run dev` beží, všetky 3 routy vracajú 200 bez runtime chýb
- [x] Jurgo: finálne schválenie textov v prehliadači, najmä CS "why"/trust-strip lokalizáciu a eKasa TODO

Closes #17