### PR TITLE
Repozicionovanie landing page na AI agentov, RAG a automatizáciu

### DIFF
--- a/app/components/HeroSection.vue
+++ b/app/components/HeroSection.vue
@@ -2,9 +2,10 @@
 const { t } = useI18n()
 
 const panelItems = [
-  { docKey: 'hero.panel.doc_invoice', vendor: 'Veľkoobchod Drevo s.r.o.', amount: '1 240,00 €', statusKey: 'hero.panel.status_done' },
-  { docKey: 'hero.panel.doc_delivery', vendor: 'Stavebniny Krajná', amount: '—', statusKey: 'hero.panel.status_review' },
-  { docKey: 'hero.panel.doc_invoice', vendor: 'IT Servis Plus', amount: '345,50 €', statusKey: 'hero.panel.status_done' }
+  { kindKey: 'hero.panel.kind_agent', textKey: 'hero.panel.row_agent', statusKey: 'hero.panel.status_done' },
+  { kindKey: 'hero.panel.kind_search', textKey: 'hero.panel.row_search', statusKey: 'hero.panel.status_done' },
+  { kindKey: 'hero.panel.kind_automation', textKey: 'hero.panel.row_automation', statusKey: 'hero.panel.status_review' },
+  { kindKey: 'hero.panel.kind_document', textKey: 'hero.panel.row_document', statusKey: 'hero.panel.status_done' }
 ]
 
 const rotatingPhrases = computed(() => [
@@ -59,9 +60,8 @@ onUnmounted(stopRotation)
           <p class="hero-panel__caption">{{ t('hero.panel_caption') }}</p>
           <ul class="hero-panel__list">
             <li v-for="(item, i) in panelItems" :key="i" class="hero-panel__row">
-              <span class="hero-panel__doc">{{ t(item.docKey) }}</span>
-              <span class="hero-panel__vendor">{{ item.vendor }}</span>
-              <span class="hero-panel__amount">{{ item.amount }}</span>
+              <span class="hero-panel__kind">{{ t(item.kindKey) }}</span>
+              <span class="hero-panel__text">{{ t(item.textKey) }}</span>
               <span
                 class="hero-panel__status"
                 :class="{ 'is-review': item.statusKey.endsWith('status_review') }"
@@ -163,7 +163,7 @@ onUnmounted(stopRotation)
 
 .hero-panel__row {
   display: grid;
-  grid-template-columns: auto 1fr auto auto;
+  grid-template-columns: auto 1fr auto;
   gap: 0.75rem;
   align-items: center;
   padding: 0.6rem 0.75rem;
@@ -172,17 +172,13 @@ onUnmounted(stopRotation)
   font-size: 0.85rem;
 }
 
-.hero-panel__doc {
+.hero-panel__kind {
   color: var(--color-text-muted);
   white-space: nowrap;
 }
 
-.hero-panel__vendor {
+.hero-panel__text {
   font-weight: 600;
-}
-
-.hero-panel__amount {
-  white-space: nowrap;
 }
 
 .hero-panel__status {
@@ -202,7 +198,7 @@ onUnmounted(stopRotation)
   }
 
   .hero-panel__row {
-    grid-template-columns: auto 1fr;
+    grid-template-columns: 1fr;
     row-gap: 0.25rem;
   }
 }

--- a/app/components/ProductCards.vue
+++ b/app/components/ProductCards.vue
@@ -31,6 +31,7 @@ const cards = [
           <p v-if="card.flagship" class="products__badge">{{ t('products.flagship_badge') }}</p>
           <h3>{{ t(`products.card_${card.id}_title`) }}</h3>
           <p class="products__desc">{{ t(`products.card_${card.id}_desc`) }}</p>
+          <p class="products__examples">{{ t(`products.card_${card.id}_examples`) }}</p>
           <p class="products__price">
             {{ t('products.price_from') }} <strong>{{ formatPrice(card.price) }} {{ t('products.price_currency') }}</strong>
           </p>
@@ -95,6 +96,12 @@ const cards = [
 .products__desc {
   margin: 0 0 0.75rem;
   font-size: 0.92rem;
+}
+
+.products__examples {
+  margin: 0 0 0.75rem;
+  color: var(--color-text-muted);
+  font-size: 0.8rem;
 }
 
 .products__price {

--- a/app/components/TrustSection.vue
+++ b/app/components/TrustSection.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+const { t } = useI18n()
+</script>
+
+<template>
+  <section id="approach" class="trust-section">
+    <div class="trust-section__inner">
+      <h2>{{ t('trust_section.title') }}</h2>
+      <p>{{ t('trust_section.p1') }}</p>
+      <p>{{ t('trust_section.p2') }}</p>
+      <p>{{ t('trust_section.p3') }}</p>
+      <p>{{ t('trust_section.p4') }}</p>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.trust-section {
+  padding: 4rem 1.5rem;
+}
+
+.trust-section__inner {
+  max-width: 42rem;
+  margin: 0 auto;
+  text-align: center;
+}
+
+.trust-section h2 {
+  font-size: clamp(1.6rem, 3vw, 2.1rem);
+  margin: 0 0 1.5rem;
+}
+
+.trust-section p {
+  margin: 0 0 0.75rem;
+  color: var(--color-text-muted);
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+.trust-section p:last-child {
+  margin-bottom: 0;
+}
+</style>

--- a/app/components/TrustStrip.vue
+++ b/app/components/TrustStrip.vue
@@ -1,8 +1,4 @@
 <script setup lang="ts">
-// TODO: trust_strip.item_2 (CS) hovorí len všeobecne "QR kód na účtenkách" —
-// SK verzia menuje konkrétny systém eKasa, pre CZ trh treba overiť s
-// marketérom, či existuje priamy ekvivalent na pomenovanie (napr. EET
-// nahradenie po roku 2023), aby štítok zostal rovnako konkrétny.
 const { t } = useI18n()
 
 const items = [1, 2, 3, 4, 5]

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -13,6 +13,7 @@ useSeoMeta({
   <HowItWorks />
   <ProductCards />
   <WhyProjentIQ />
+  <TrustSection />
   <Testimonials />
   <FaqSection />
   <CtaBand />

--- a/i18n/locales/cs.json
+++ b/i18n/locales/cs.json
@@ -7,8 +7,8 @@
     "cta_demo": "Vyžádat demo"
   },
   "meta": {
-    "title": "ProjentIQ — Vytěžování faktur a dokladů pro firmy",
-    "description": "Automaticky vytěžíme údaje z faktur a dokladů do vašeho účetnictví. Napojení na Pohodu a Omegu, data zůstávají v EU. Ukážeme vám to na vaší faktuře."
+    "title": "Projentiq – AI agenti, znalostní systémy a automatizace procesů",
+    "description": "Projentiq pomáhá firmám zavádět AI agenty, RAG znalostní systémy a automatizace postavené na vlastních datech a procesech."
   },
   "a11y": {
     "skip_link": "Přeskočit na obsah"
@@ -28,15 +28,21 @@
     "gdpr_link": "Ochrana osobních údajů a cookies"
   },
   "hero": {
-    "title": "Doklady přepíše software, ne váš člověk.",
-    "lead": "Nahrajete nebo vyfotíte doklad, ProjentIQ z něj vytáhne údaje a připraví je do vašeho účetnictví. Vy je už jen zkontrolujete a schválíte. Vaše data přitom zůstávají u vás, v EU.",
-    "cta_contact": "Napsat nám",
+    "title": "AI systémy, které pracují s vašimi daty.",
+    "lead": "Navrhujeme AI agenty, znalostní systémy a automatizace, které pomáhají týmům vyhledávat informace, zpracovávat dokumenty a provádět opakující se úkoly.",
+    "cta_contact": "Kontaktovat nás",
     "panel_caption": "Ukázka rozhraní — ilustrační data",
     "panel": {
-      "doc_invoice": "Faktura",
-      "doc_delivery": "Dodací list",
-      "status_done": "Zpracováno",
-      "status_review": "Čeká na kontrolu"
+      "kind_agent": "AI agent",
+      "kind_search": "Vyhledávání",
+      "kind_automation": "Automatizace",
+      "kind_document": "Dokument",
+      "row_agent": "Odpověděl na otázku o stavu objednávky",
+      "row_search": "Našel smlouvu podle klíčových slov",
+      "row_automation": "Zpracoval e-mailovou objednávku",
+      "row_document": "Faktura — Velkoobchod Dřevo s.r.o.",
+      "status_done": "Hotovo",
+      "status_review": "Probíhá"
     },
     "rotator": {
       "item_1": "Vytěží částky, IČO a splatnost z faktur.",
@@ -45,45 +51,55 @@
     }
   },
   "trust_strip": {
-    "item_1": "Pohoda · Omega · iDoklad",
-    "item_2": "QR kód na účtenkách",
-    "item_3": "Data v EU",
+    "item_1": "ERP, CRM i firemní disky",
+    "item_2": "Data v EU",
+    "item_3": "Demo na vašich datech",
     "item_4": "Čeština",
-    "item_5": "Demo do 2 týdnů"
+    "item_5": "Nasazení do 2 týdnů"
   },
   "how_it_works": {
-    "title": "Jak to funguje",
-    "step_1_title": "Nahrajete doklad",
-    "step_1_desc": "PDF, sken nebo fotka z mobilu, klidně i víc najednou.",
-    "step_2_title": "Systém vytěží údaje",
-    "step_2_desc": "Dodavatele, částky, DPH, splatnost i položky.",
-    "step_3_title": "Zkontrolujete návrh",
-    "step_3_desc": "Sporná pole jsou zvýrazněná, opravíte je kliknutím.",
-    "step_4_title": "Zápis do účetnictví",
-    "step_4_desc": "Údaje jdou do Pohody, Omegy nebo vašeho systému."
+    "title": "Jak probíhá spolupráce",
+    "step_1_title": "Analýza procesu",
+    "step_1_desc": "Společně identifikujeme úkoly, které zabírají čas nebo se opakují.",
+    "step_2_title": "Návrh řešení",
+    "step_2_desc": "Navrhneme AI agenta, automatizaci nebo znalostní systém podle vašich dat a procesů.",
+    "step_3_title": "Pilotní nasazení",
+    "step_3_desc": "Řešení otestujeme na reálných dokumentech a procesech.",
+    "step_4_title": "Produkční používání",
+    "step_4_desc": "Po schválení se systém stává součástí každodenního provozu."
   },
   "products": {
     "title": "Řešení a ceník",
     "price_from": "od",
     "price_currency": "€",
     "flagship_badge": "Hlavní produkt",
-    "card_1_title": "Vytěžování dokladů",
-    "card_1_desc": "Faktury, účtenky a dodací listy automaticky do účetnictví. Vy jen schválíte.",
-    "card_2_title": "RAG znalostní báze",
-    "card_2_desc": "Zeptejte se svých dokumentů a dostanete odpověď — vždy s citací zdroje.",
-    "card_3_title": "AI agenti a automatizace",
-    "card_3_desc": "E-mailoví agenti, schvalování a napojení na CRM či interní systémy."
+    "card_1_title": "AI Agenti",
+    "card_1_desc": "AI asistenti napojení na vaše dokumenty, data a firemní systémy.",
+    "card_1_examples": "Interní asistent · Zákaznická podpora · Obchodní asistent · Provozní asistent",
+    "card_2_title": "RAG Znalostní Systémy",
+    "card_2_desc": "AI chatboti a asistenti, kteří odpovídají na základě interní dokumentace vaší firmy.",
+    "card_2_examples": "Firemní znalostní báze · Technická dokumentace · Interní procesy · Zákaznická podpora",
+    "card_3_title": "Automatizace Procesů",
+    "card_3_desc": "Automatizace dokumentů, e-mailů a opakujících se úkolů.",
+    "card_3_examples": "Zpracování faktur · Zpracování e-mailů · Generování reportů · Synchronizace dat"
   },
   "why": {
     "title": "Proč ProjentIQ",
-    "item_1_title": "Data zůstávají u vás",
-    "item_1_desc": "Zpracování v EU, žádné sdílení s třetími stranami.",
-    "item_2_title": "Napojení na české i slovenské systémy",
-    "item_2_desc": "Pohoda, Omega, iDoklad a další.",
-    "item_3_title": "Skutečná čeština a slovenština",
-    "item_3_desc": "Laděno na české i slovenské doklady, diakritiku a jazyk.",
-    "item_4_title": "Demo na vašich datech",
-    "item_4_desc": "Před objednávkou uvidíte výsledek, ne slib."
+    "item_1_title": "Pracujeme s vašimi daty",
+    "item_1_desc": "AI řešení jsou postavená na dokumentech, systémech a informacích, které už ve firmě používáte.",
+    "item_2_title": "Řešení na míru",
+    "item_2_desc": "Každá firma funguje jinak. Návrh přizpůsobujeme konkrétnímu procesu.",
+    "item_3_title": "Nejprve ukázka, pak rozhodnutí",
+    "item_3_desc": "Před objednávkou uvidíte řešení na vlastních datech.",
+    "item_4_title": "Integrace na stávající systémy",
+    "item_4_desc": "ERP, CRM, SharePoint, Google Drive, e-mail, databáze nebo API."
+  },
+  "trust_section": {
+    "title": "Technologie prodáváme až poté, co pochopíme problém.",
+    "p1": "Nevytváříme univerzální AI řešení.",
+    "p2": "Nejdříve pochopíme proces, který chcete zlepšit. Až poté navrhujeme technologii.",
+    "p3": "Cílem není mít více AI.",
+    "p4": "Cílem je mít méně manuální práce, rychlejší přístup k informacím a jednodušší procesy."
   },
   "testimonials": {
     "title": "První nasazení připravujeme",
@@ -101,8 +117,8 @@
     "a4": "Sporná pole jsou vždy zvýrazněná ke kontrole a nic se nezapíše bez vašeho schválení. Systém se navíc učí z vašich oprav."
   },
   "cta_band": {
-    "title": "Ukážeme vám to na vaší faktuře.",
-    "lead": "Bezplatná konzultace a demo na reálném dokladu z vaší firmy."
+    "title": "Ukážeme vám to na vašich datech.",
+    "lead": "Pošlete nám proces nebo problém, který chcete řešit. Navrhneme konkrétní postup a ukázku řešení na reálných firemních datech."
   },
   "contact": {
     "title": "Ozvěte se nám",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -7,8 +7,8 @@
     "cta_demo": "Request a demo"
   },
   "meta": {
-    "title": "ProjentIQ — Invoice and document extraction for businesses",
-    "description": "We automatically extract data from your invoices and documents into your accounting system. Connects to Pohoda and Omega, data stays in the EU. We'll show you on your own invoice."
+    "title": "Projentiq – AI agents, knowledge systems, and process automation",
+    "description": "Projentiq helps companies deploy AI agents, RAG knowledge systems, and automations built on their own data and processes."
   },
   "a11y": {
     "skip_link": "Skip to content"
@@ -28,15 +28,21 @@
     "gdpr_link": "Privacy & cookies"
   },
   "hero": {
-    "title": "Software processes your documents, not your staff.",
-    "lead": "Upload or photograph a document and ProjentIQ pulls out the data and prepares it for your accounting system. You just review and approve it. Your data stays with you, in the EU.",
-    "cta_contact": "Get in touch",
+    "title": "AI systems that work with your data.",
+    "lead": "We design AI agents, knowledge systems, and automations that help teams find information, process documents, and handle repetitive tasks.",
+    "cta_contact": "Contact us",
     "panel_caption": "Interface preview — illustrative data",
     "panel": {
-      "doc_invoice": "Invoice",
-      "doc_delivery": "Delivery note",
-      "status_done": "Processed",
-      "status_review": "Awaiting review"
+      "kind_agent": "AI agent",
+      "kind_search": "Search",
+      "kind_automation": "Automation",
+      "kind_document": "Document",
+      "row_agent": "Answered a question about order status",
+      "row_search": "Found a contract by keyword",
+      "row_automation": "Processed an email order",
+      "row_document": "Invoice — Drevo Wholesale Ltd.",
+      "status_done": "Done",
+      "status_review": "In progress"
     },
     "rotator": {
       "item_1": "Extracts amounts, tax IDs, and due dates from invoices.",
@@ -45,45 +51,55 @@
     }
   },
   "trust_strip": {
-    "item_1": "Pohoda · Omega · iDoklad",
-    "item_2": "eKasa QR receipts",
-    "item_3": "Data stored in the EU",
+    "item_1": "ERP, CRM, and company drives",
+    "item_2": "Data stored in the EU",
+    "item_3": "Demo on your own data",
     "item_4": "Slovak & Czech",
-    "item_5": "Demo within 2 weeks"
+    "item_5": "Deployment within 2 weeks"
   },
   "how_it_works": {
-    "title": "How it works",
-    "step_1_title": "Upload the document",
-    "step_1_desc": "A PDF, a scan, or a phone photo — upload several at once if you like.",
-    "step_2_title": "The system extracts the data",
-    "step_2_desc": "Vendor, amounts, VAT, due date, and line items.",
-    "step_3_title": "You review the draft",
-    "step_3_desc": "Flagged fields are highlighted — fix them with a click.",
-    "step_4_title": "Entry into your accounting system",
-    "step_4_desc": "Data goes into Pohoda, Omega, or your own system."
+    "title": "How we work together",
+    "step_1_title": "Process analysis",
+    "step_1_desc": "Together we identify tasks that take up time or repeat.",
+    "step_2_title": "Solution design",
+    "step_2_desc": "We design an AI agent, automation, or knowledge system based on your data and processes.",
+    "step_3_title": "Pilot deployment",
+    "step_3_desc": "We test the solution on real documents and processes.",
+    "step_4_title": "Production use",
+    "step_4_desc": "Once approved, the system becomes part of daily operations."
   },
   "products": {
     "title": "Solutions & pricing",
     "price_from": "from",
     "price_currency": "€",
     "flagship_badge": "Flagship product",
-    "card_1_title": "Document extraction",
-    "card_1_desc": "Invoices, receipts, and delivery notes go straight into your accounting system. You just approve them.",
-    "card_2_title": "RAG knowledge base",
-    "card_2_desc": "Ask your documents a question and get an answer — always with a source citation.",
-    "card_3_title": "AI agents & automation",
-    "card_3_desc": "Email agents, approval flows, and connections to your CRM or internal systems."
+    "card_1_title": "AI Agents",
+    "card_1_desc": "AI assistants connected to your documents, data, and company systems.",
+    "card_1_examples": "Internal assistant · Customer support · Sales assistant · Operations assistant",
+    "card_2_title": "RAG Knowledge Systems",
+    "card_2_desc": "AI chatbots and assistants that answer based on your company's internal documentation.",
+    "card_2_examples": "Company knowledge base · Technical documentation · Internal processes · Customer support",
+    "card_3_title": "Process Automation",
+    "card_3_desc": "Automation of documents, emails, and repetitive tasks.",
+    "card_3_examples": "Invoice processing · Email processing · Report generation · Data synchronization"
   },
   "why": {
     "title": "Why ProjentIQ",
-    "item_1_title": "Your data stays with you",
-    "item_1_desc": "Processing happens in the EU, with no sharing with third parties.",
-    "item_2_title": "Connects to Slovak and Czech systems",
-    "item_2_desc": "Pohoda, Omega, iDoklad, and more.",
-    "item_3_title": "Built for Slovak and Czech",
-    "item_3_desc": "Tuned for local documents, diacritics, and language.",
-    "item_4_title": "Demo on your own data",
-    "item_4_desc": "Before you commit, you'll see a result, not a promise."
+    "item_1_title": "We work with your data",
+    "item_1_desc": "AI solutions are built on the documents, systems, and information your company already uses.",
+    "item_2_title": "Tailored to your business",
+    "item_2_desc": "Every company works differently. We adapt the design to your specific process.",
+    "item_3_title": "See it first, decide after",
+    "item_3_desc": "Before you commit, you'll see the solution working on your own data.",
+    "item_4_title": "Integrates with your existing systems",
+    "item_4_desc": "ERP, CRM, SharePoint, Google Drive, email, databases, or APIs."
+  },
+  "trust_section": {
+    "title": "We sell technology only after we understand the problem.",
+    "p1": "We don't build generic AI solutions.",
+    "p2": "We first understand the process you want to improve. Only then do we design the technology.",
+    "p3": "The goal isn't to have more AI.",
+    "p4": "The goal is less manual work, faster access to information, and simpler processes."
   },
   "testimonials": {
     "title": "Our first deployments are underway",
@@ -101,8 +117,8 @@
     "a4": "Flagged fields are always highlighted for review, and nothing gets recorded without your approval. The system also learns from your corrections."
   },
   "cta_band": {
-    "title": "We'll show you on your own invoice.",
-    "lead": "A free consultation and a demo on a real document from your company."
+    "title": "We'll show you on your own data.",
+    "lead": "Send us the process or problem you want to solve. We'll design a concrete approach and demo the solution on real company data."
   },
   "contact": {
     "title": "Get in touch",

--- a/i18n/locales/sk.json
+++ b/i18n/locales/sk.json
@@ -7,8 +7,8 @@
     "cta_demo": "Požiadať o demo"
   },
   "meta": {
-    "title": "ProjentIQ — Vyťažovanie faktúr a dokladov pre firmy",
-    "description": "Automaticky vyťažíme údaje z faktúr a dokladov do vášho účtovníctva. Napojenie na Pohodu a Omegu, dáta zostávajú v EÚ. Ukážeme vám to na vašej faktúre."
+    "title": "Projentiq – AI agenti, znalostné systémy a automatizácia procesov",
+    "description": "Projentiq pomáha firmám zavádzať AI agentov, RAG znalostné systémy a automatizácie postavené na vlastných dátach a procesoch."
   },
   "a11y": {
     "skip_link": "Preskočiť na obsah"
@@ -28,15 +28,21 @@
     "gdpr_link": "Ochrana osobných údajov a cookies"
   },
   "hero": {
-    "title": "Doklady prepíše softvér, nie váš človek.",
-    "lead": "Nahráte alebo odfotíte doklad, ProjentIQ z neho vytiahne údaje a pripraví ich do vášho účtovníctva. Vy ich už len skontrolujete a schválite. Vaše dáta pritom zostávajú u vás, v EÚ.",
-    "cta_contact": "Napísať nám",
+    "title": "AI systémy, ktoré pracujú s vašimi dátami.",
+    "lead": "Navrhujeme AI agentov, znalostné systémy a automatizácie, ktoré pomáhajú tímom vyhľadávať informácie, spracovávať dokumenty a vykonávať opakujúce sa úlohy.",
+    "cta_contact": "Kontaktovať nás",
     "panel_caption": "Ukážka rozhrania — ilustračné dáta",
     "panel": {
-      "doc_invoice": "Faktúra",
-      "doc_delivery": "Dodací list",
-      "status_done": "Spracované",
-      "status_review": "Čaká na kontrolu"
+      "kind_agent": "AI agent",
+      "kind_search": "Vyhľadávanie",
+      "kind_automation": "Automatizácia",
+      "kind_document": "Dokument",
+      "row_agent": "Odpovedal na otázku o stave objednávky",
+      "row_search": "Našiel zmluvu podľa kľúčových slov",
+      "row_automation": "Spracoval e-mailovú objednávku",
+      "row_document": "Faktúra — Veľkoobchod Drevo s.r.o.",
+      "status_done": "Hotovo",
+      "status_review": "Prebieha"
     },
     "rotator": {
       "item_1": "Vyťaží sumy, IČO a splatnosť z faktúr.",
@@ -45,45 +51,55 @@
     }
   },
   "trust_strip": {
-    "item_1": "Pohoda · Omega · iDoklad",
-    "item_2": "eKasa QR pre bločky",
-    "item_3": "Dáta v EÚ",
+    "item_1": "ERP, CRM aj firemné disky",
+    "item_2": "Dáta v EÚ",
+    "item_3": "Demo na vašich dátach",
     "item_4": "Slovenčina",
-    "item_5": "Demo do 2 týždňov"
+    "item_5": "Nasadenie do 2 týždňov"
   },
   "how_it_works": {
-    "title": "Ako to funguje",
-    "step_1_title": "Nahráte doklad",
-    "step_1_desc": "PDF, sken alebo fotka z mobilu, aj viac naraz.",
-    "step_2_title": "Systém vyťaží údaje",
-    "step_2_desc": "Dodávateľ, sumy, DPH, splatnosť aj položky.",
-    "step_3_title": "Skontrolujete návrh",
-    "step_3_desc": "Sporné polia sú zvýraznené, opravíte ich klikom.",
-    "step_4_title": "Zápis do účtovníctva",
-    "step_4_desc": "Údaje idú do Pohody, Omegy alebo vášho systému."
+    "title": "Ako prebieha spolupráca",
+    "step_1_title": "Analýza procesu",
+    "step_1_desc": "Spoločne identifikujeme úlohy, ktoré zaberajú čas alebo sa opakujú.",
+    "step_2_title": "Návrh riešenia",
+    "step_2_desc": "Navrhneme AI agenta, automatizáciu alebo znalostný systém podľa vašich dát a procesov.",
+    "step_3_title": "Pilotné nasadenie",
+    "step_3_desc": "Riešenie otestujeme na reálnych dokumentoch a procesoch.",
+    "step_4_title": "Produkčné používanie",
+    "step_4_desc": "Po schválení sa systém stáva súčasťou každodennej prevádzky."
   },
   "products": {
     "title": "Riešenia a ceny",
     "price_from": "od",
     "price_currency": "€",
     "flagship_badge": "Hlavný produkt",
-    "card_1_title": "Vyťažovanie dokladov",
-    "card_1_desc": "Faktúry, bločky a dodacie listy automaticky do účtovníctva. Vy len schválite.",
-    "card_2_title": "RAG znalostná báza",
-    "card_2_desc": "Opýtajte sa svojich dokumentov a dostanete odpoveď — vždy s citáciou zdroja.",
-    "card_3_title": "AI agenti & automatizácia",
-    "card_3_desc": "E-mailoví agenti, schvaľovania a napojenie na CRM či interné systémy."
+    "card_1_title": "AI Agenti",
+    "card_1_desc": "AI asistenti napojení na vaše dokumenty, dáta a firemné systémy.",
+    "card_1_examples": "Interný asistent · Zákaznícka podpora · Obchodný asistent · Operačný asistent",
+    "card_2_title": "RAG Znalostné Systémy",
+    "card_2_desc": "AI chatboty a asistenti, ktorí odpovedajú na základe internej dokumentácie vašej firmy.",
+    "card_2_examples": "Firemná znalostná báza · Technická dokumentácia · Interné procesy · Zákaznícka podpora",
+    "card_3_title": "Automatizácia Procesov",
+    "card_3_desc": "Automatizácia dokumentov, e-mailov a opakujúcich sa úloh.",
+    "card_3_examples": "Spracovanie faktúr · Spracovanie e-mailov · Generovanie reportov · Synchronizácia dát"
   },
   "why": {
     "title": "Prečo ProjentIQ",
-    "item_1_title": "Dáta zostávajú u vás",
-    "item_1_desc": "Spracovanie v EÚ, žiadne zdieľanie s tretími stranami.",
-    "item_2_title": "Napojenie na slovenské systémy",
-    "item_2_desc": "Pohoda, Omega, iDoklad a ďalšie.",
-    "item_3_title": "Naozajstná slovenčina",
-    "item_3_desc": "Ladené na slovenské doklady, diakritiku a jazyk.",
-    "item_4_title": "Demo na vašich dátach",
-    "item_4_desc": "Pred objednávkou uvidíte výsledok, nie sľub."
+    "item_1_title": "Pracujeme s vašimi dátami",
+    "item_1_desc": "AI riešenia sú postavené na dokumentoch, systémoch a informáciách, ktoré už vo firme používate.",
+    "item_2_title": "Riešenie na mieru",
+    "item_2_desc": "Každá firma funguje inak. Návrh prispôsobujeme konkrétnemu procesu.",
+    "item_3_title": "Najprv ukážka, potom rozhodnutie",
+    "item_3_desc": "Pred objednávkou vidíte riešenie na vlastných dátach.",
+    "item_4_title": "Integrácia na existujúce systémy",
+    "item_4_desc": "ERP, CRM, SharePoint, Google Drive, email, databázy alebo API."
+  },
+  "trust_section": {
+    "title": "Technológie predávame až po tom, čo pochopíme problém.",
+    "p1": "Nevytvárame univerzálne AI riešenia.",
+    "p2": "Najskôr pochopíme proces, ktorý chcete zlepšiť. Až potom navrhujeme technológiu.",
+    "p3": "Cieľom nie je mať viac AI.",
+    "p4": "Cieľom je mať menej manuálnej práce, rýchlejší prístup k informáciám a jednoduchšie procesy."
   },
   "testimonials": {
     "title": "Prvé nasadenia pripravujeme",
@@ -101,8 +117,8 @@
     "a4": "Sporné polia sú vždy zvýraznené na kontrolu a nič sa nezapíše bez vášho schválenia. Systém sa navyše učí z vašich opráv."
   },
   "cta_band": {
-    "title": "Ukážeme vám to na vašej faktúre.",
-    "lead": "Bezplatná konzultácia a demo na reálnom doklade z vašej firmy."
+    "title": "Ukážeme vám to na vašich dátach.",
+    "lead": "Pošlite nám proces alebo problém, ktorý chcete riešiť. Navrhneme konkrétny postup a ukážku riešenia na reálnych firemných dátach."
   },
   "contact": {
     "title": "Ozvite sa nám",


### PR DESCRIPTION
## Summary
- Prepísané copy naprieč hero, "Ako prebieha spolupráca", službami, "Prečo Projentiq" a záverečnou CTA sekciou vo všetkých troch jazykoch (sk/cs/en) — značka sa teraz profiluje ako AI agenti, RAG znalostné systémy a automatizácia procesov, spracovanie dokladov je len jedna zo služieb
- Hero vizuál prerobený zo zoznamu faktúr na mix AI agenta, vyhľadávania, automatizácie a dokumentu
- Služby preusporiadané (AI Agenti → RAG Znalostné Systémy → Automatizácia Procesov) a doplnené o príklady použitia
- Trust strip zbavený konkrétnych účtovných systémov (Pohoda/Omega/iDoklad/eKasa) v prospech širšej integračnej ponuky (ERP, CRM, firemné disky)
- Nová sekcia `TrustSection.vue` ("Technológie predávame až po tom, čo pochopíme problém") vložená medzi "Prečo Projentiq" a FAQ
- Aktualizované SEO meta title/description

## Test plan
- [x] `npm run build` (nuxt build) prebehol bez chýb
- [x] JSON lokalizačné súbory (sk/cs/en) validné
- [x] Vizuálna kontrola hero panelu a novej sekcie v prehliadači (`npm run dev`)