### PR TITLE
Fix: Netlify publish dir je dist, nie .output/public

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ logs
 .env
 .env.*
 !.env.example
+
+# Local Netlify folder
+.netlify

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,11 +1,6 @@
 [build]
   command = "npm run generate"
-  publish = ".output/public"
+  publish = "dist"
 
 [build.environment]
   NODE_VERSION = "24"
-
-[[redirects]]
-  from = "/*"
-  to = "/404.html"
-  status = 404


### PR DESCRIPTION
Opravuje zlyhaný produkčný deploy po mergnutí #21.

## Čo sa stalo
Po mergnutí PR #21 sa spustil automatický Netlify build, ktorý zlyhal:

\`\`\`
Deploy did not succeed: Deploy directory '.output/public' does not exist
Build failed due to a user error: Build script returned non-zero exit code: 2
\`\`\`

## Root cause
Reprodukoval som to lokálne cez \`netlify build\` (rovnaká emulácia ako skutočné Netlify CI prostredie). V tomto prostredí Nitro automaticky deteguje \`NETLIFY\` env premennú a prepne preset na **netlify-static**, ktorý generuje statický výstup do \`dist/\` — nie do \`.output/public/\`, kam \`nuxt generate\` zapisuje len mimo Netlify kontextu (čo som overoval lokálne pri pôvodnom PR #21, preto mi to tam prešlo bez povšimnutia). \`netlify.toml\` ukazoval na zlý priečinok.

## Fix
- \`publish = "dist"\` namiesto \`.output/public\`
- Odstránený manuálny \`[[redirects]]\` blok pre 404 — netlify-static preset si už generuje vlastný presnejší \`_redirects\` (vrátane \`/sitemap.xml → /sitemap_index.xml\`), takže bol redundantný
- Pridané \`.netlify\` do \`.gitignore\` (vzniklo pri \`netlify link\`, ktorý som spustil na prepojenie repa s existujúcim \`projentiq\` site)

## Test plan
- [x] \`netlify build\` lokálne — build aj deploy-dir teraz sedia, žiadna chyba
- [ ] Skutočný produkčný deploy po mergnutí tohto PR