### PR TITLE
Design fáza 3/6: Trust strip, How it works, Product cards

### DIFF
--- a/app/components/HowItWorks.vue
+++ b/app/components/HowItWorks.vue
@@ -1,7 +1,12 @@
 <script setup lang="ts">
 const { t } = useI18n()
 
-const steps = [1, 2, 3, 4]
+const steps = [
+  { id: 1, icon: 'tabler:search' },
+  { id: 2, icon: 'tabler:bulb' },
+  { id: 3, icon: 'tabler:rocket' },
+  { id: 4, icon: 'tabler:trending-up' }
+]
 </script>
 
 <template>
@@ -10,10 +15,13 @@ const steps = [1, 2, 3, 4]
       <h2>{{ t('how_it_works.title') }}</h2>
 
       <ol class="how-it-works__list">
-        <li v-for="step in steps" :key="step" class="how-it-works__step">
-          <span class="how-it-works__number" aria-hidden="true">{{ step }}</span>
-          <h3>{{ t(`how_it_works.step_${step}_title`) }}</h3>
-          <p>{{ t(`how_it_works.step_${step}_desc`) }}</p>
+        <li v-for="step in steps" :key="step.id" class="how-it-works__step">
+          <span class="how-it-works__token" aria-hidden="true">
+            <Icon :name="step.icon" class="how-it-works__icon" />
+            <span class="how-it-works__number">{{ step.id }}</span>
+          </span>
+          <h3>{{ t(`how_it_works.step_${step.id}_title`) }}</h3>
+          <p>{{ t(`how_it_works.step_${step.id}_desc`) }}</p>
         </li>
       </ol>
     </div>
@@ -22,11 +30,12 @@ const steps = [1, 2, 3, 4]
 
 <style scoped>
 .how-it-works {
-  padding: 4rem 1.5rem;
+  padding: var(--section-y) 1.5rem;
+  background: var(--color-bg);
 }
 
 .how-it-works__inner {
-  max-width: 72rem;
+  max-width: var(--container);
   margin: 0 auto;
 }
 
@@ -45,24 +54,41 @@ const steps = [1, 2, 3, 4]
 }
 
 .how-it-works__step {
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: 12px;
-  padding: 1.5rem;
+  position: relative;
 }
 
-.how-it-works__number {
+.how-it-works__token {
+  position: relative;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 2rem;
-  height: 2rem;
+  width: 3rem;
+  height: 3rem;
+  border-radius: var(--r-md);
+  background: var(--color-accent-soft);
+  margin-bottom: 1rem;
+}
+
+.how-it-works__icon {
+  width: 22px;
+  height: 22px;
+  color: var(--color-accent);
+}
+
+.how-it-works__number {
+  position: absolute;
+  top: -0.4rem;
+  right: -0.4rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.25rem;
+  height: 1.25rem;
   border-radius: 50%;
   background: var(--color-accent-strong);
   color: #fff;
-  font-weight: 700;
-  font-size: 0.9rem;
-  margin-bottom: 0.75rem;
+  font-size: 0.65rem;
+  font-weight: var(--fw-bold);
 }
 
 .how-it-works__step h3 {
@@ -74,6 +100,17 @@ const steps = [1, 2, 3, 4]
   margin: 0;
   color: var(--color-text-muted);
   font-size: 0.9rem;
+}
+
+@media (min-width: 56.01rem) {
+  .how-it-works__step:not(:last-child)::after {
+    content: '';
+    position: absolute;
+    top: 1.5rem;
+    left: 3rem;
+    right: -1.5rem;
+    border-top: 2px dashed var(--color-border-strong);
+  }
 }
 
 @media (max-width: 56rem) {

--- a/app/components/ProductCards.vue
+++ b/app/components/ProductCards.vue
@@ -10,10 +10,14 @@ function formatPrice(value: number) {
 // TODO: placeholder jednorazové ceny za nasadenie (copy spec časť 5) —
 // potvrdiť reálne sumy aj menu pre CS trh (€ vs Kč) pred spustením.
 const cards = [
-  { id: 1, flagship: true, price: 2000 },
-  { id: 2, flagship: false, price: 4000 },
-  { id: 3, flagship: false, price: 8000 }
+  { id: 1, flagship: true, price: 2000, icon: 'tabler:robot' },
+  { id: 2, flagship: false, price: 4000, icon: 'tabler:brain' },
+  { id: 3, flagship: false, price: 8000, icon: 'tabler:settings-automation' }
 ]
+
+function examples(id: number) {
+  return t(`products.card_${id}_examples`).split(' · ')
+}
 </script>
 
 <template>
@@ -29,12 +33,21 @@ const cards = [
           :class="{ 'is-flagship': card.flagship }"
         >
           <p v-if="card.flagship" class="products__badge">{{ t('products.flagship_badge') }}</p>
+          <span class="products__icon">
+            <Icon :name="card.icon" aria-hidden="true" />
+          </span>
           <h3>{{ t(`products.card_${card.id}_title`) }}</h3>
           <p class="products__desc">{{ t(`products.card_${card.id}_desc`) }}</p>
-          <p class="products__examples">{{ t(`products.card_${card.id}_examples`) }}</p>
+          <ul class="products__tags">
+            <li v-for="example in examples(card.id)" :key="example" class="products__tag">{{ example }}</li>
+          </ul>
           <p class="products__price">
             {{ t('products.price_from') }} <strong>{{ formatPrice(card.price) }} {{ t('products.price_currency') }}</strong>
           </p>
+          <a href="#demo" class="products__cta">
+            {{ t('nav.cta_demo') }}
+            <Icon name="tabler:arrow-right" aria-hidden="true" />
+          </a>
         </article>
       </div>
     </div>
@@ -43,11 +56,12 @@ const cards = [
 
 <style scoped>
 .products {
-  padding: 4rem 1.5rem;
+  padding: var(--section-y) 1.5rem;
+  background: var(--color-surface-1);
 }
 
 .products__inner {
-  max-width: 72rem;
+  max-width: var(--container);
   margin: 0 auto;
 }
 
@@ -63,29 +77,69 @@ const cards = [
 }
 
 .products__card {
+  position: relative;
   display: flex;
   flex-direction: column;
-  background: var(--color-surface);
+  background: var(--color-surface-2);
   border: 1px solid var(--color-border);
-  border-radius: 12px;
+  border-radius: var(--r-lg);
   padding: 1.75rem;
+  box-shadow: var(--hairline-top);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.products__card::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: var(--r-lg);
+  right: var(--r-lg);
+  height: 2px;
+  background: var(--gradient-accent, var(--color-accent-strong));
+  border-radius: var(--r-full);
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+
+.products__card:hover {
+  transform: translateY(-3px);
+  box-shadow: var(--sh-lg), var(--hairline-top);
+}
+
+.products__card:hover::before {
+  opacity: 1;
 }
 
 .products__card.is-flagship {
-  border-color: var(--color-accent);
+  border-color: var(--color-accent-border);
+  box-shadow: var(--sh-glow), var(--hairline-top);
 }
 
 .products__badge {
   align-self: flex-start;
-  margin: 0 0 0.75rem;
+  margin: 0 0 1rem;
   padding: 0.2rem 0.6rem;
-  border-radius: 999px;
-  background: var(--color-accent-strong);
-  color: #fff;
+  border-radius: var(--r-full);
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+  font-family: var(--font-mono);
   font-size: 0.7rem;
-  font-weight: 700;
+  font-weight: var(--fw-semibold);
   text-transform: uppercase;
-  letter-spacing: 0.04em;
+  letter-spacing: var(--tracking-wide);
+}
+
+.products__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  margin-bottom: 1rem;
+  border-radius: var(--r-md);
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+  font-size: 22px;
 }
 
 .products__card h3 {
@@ -94,26 +148,60 @@ const cards = [
 }
 
 .products__desc {
-  margin: 0 0 0.75rem;
+  margin: 0 0 1rem;
   font-size: 0.92rem;
 }
 
-.products__examples {
-  margin: 0 0 0.75rem;
+.products__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin: 0 0 1.25rem;
+  padding: 0;
+  list-style: none;
+}
+
+.products__tag {
+  padding: 0.2rem 0.55rem;
+  border-radius: var(--r-full);
+  background: var(--color-surface-3);
   color: var(--color-text-muted);
-  font-size: 0.8rem;
+  font-size: 0.75rem;
 }
 
 .products__price {
   margin: auto 0 0;
   padding-top: 1rem;
   border-top: 1px solid var(--color-border);
-  font-size: 0.95rem;
+  font-family: var(--font-mono);
+  font-size: 0.9rem;
 }
 
 .products__price strong {
-  font-size: 1.2rem;
+  font-size: 1.1rem;
+  font-weight: var(--fw-semibold);
   color: var(--color-accent);
+}
+
+.products__cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  margin-top: 0.85rem;
+  color: var(--color-accent);
+  font-size: 0.9rem;
+  font-weight: var(--fw-semibold);
+  text-decoration: none;
+}
+
+.products__cta :deep(svg) {
+  width: 16px;
+  height: 16px;
+  transition: transform 0.15s ease;
+}
+
+.products__cta:hover :deep(svg) {
+  transform: translateX(2px);
 }
 
 @media (max-width: 56rem) {

--- a/app/components/TrustStrip.vue
+++ b/app/components/TrustStrip.vue
@@ -1,14 +1,21 @@
 <script setup lang="ts">
 const { t } = useI18n()
 
-const items = [1, 2, 3, 4, 5]
+const items = [
+  { id: 1, icon: 'tabler:plug-connected' },
+  { id: 2, icon: 'tabler:lock' },
+  { id: 3, icon: 'tabler:presentation' },
+  { id: 4, icon: 'tabler:world' },
+  { id: 5, icon: 'tabler:clock' }
+]
 </script>
 
 <template>
   <section class="trust-strip">
     <ul class="trust-strip__list">
-      <li v-for="item in items" :key="item" class="trust-strip__item">
-        {{ t(`trust_strip.item_${item}`) }}
+      <li v-for="item in items" :key="item.id" class="trust-strip__item">
+        <Icon :name="item.icon" class="trust-strip__icon" />
+        {{ t(`trust_strip.item_${item.id}`) }}
       </li>
     </ul>
   </section>
@@ -16,12 +23,14 @@ const items = [1, 2, 3, 4, 5]
 
 <style scoped>
 .trust-strip {
-  padding: 1.5rem;
+  padding: 1.25rem 1.5rem;
+  background: var(--color-surface-1);
+  border-top: 1px solid var(--color-border);
   border-bottom: 1px solid var(--color-border);
 }
 
 .trust-strip__list {
-  max-width: 72rem;
+  max-width: var(--container);
   margin: 0 auto;
   padding: 0;
   list-style: none;
@@ -32,9 +41,19 @@ const items = [1, 2, 3, 4, 5]
 }
 
 .trust-strip__item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
   color: var(--color-text-muted);
   font-size: 0.85rem;
-  font-weight: 600;
+  font-weight: var(--fw-medium);
   white-space: nowrap;
+}
+
+.trust-strip__icon {
+  width: 16px;
+  height: 16px;
+  color: var(--color-accent);
+  flex-shrink: 0;
 }
 </style>


### PR DESCRIPTION
Tretia z 6 fázovaných PR pre vizuálne doladenie podľa \`.claude/projentiq_design_SPEC.md\` (časť 3: Trust strip, How it works, Product cards).

## Summary
**Sekčný rytmus** (časť 4 — striedanie bg/surface-1): hero (bg) → trust strip (surface-1, samostatný pruh) → how it works (bg) → product cards (surface-1).

**Trust strip** — položky teraz chipy s ikonou (plug-connected/lock/presentation/world/clock), žiadne logá firiem (spec to explicitne zakazuje).

**How it works** — číslovaný token prerobený na accent-soft štvorec s ikonou (search/bulb/rocket/trending-up) + malý accent-strong krúžok s číslom v rohu. Na desktope (>56rem) spája tokeny prerušovaná čiara (vizuálny „tok"), na mobile/tablet skrytá.

**Product cards** — ikona v accent-soft štvorci, príklady použitia ako tag pills namiesto jedného textového riadku, hover s \`translateY(-3px)\` + horným gradientovým pruhom, hlavný produkt odlíšený \`--sh-glow\` + accent borderom (nie plnou farbou), badge prerobený na mono/accent-soft, pridané jemné „→" CTA pod cenou.

## Test plan
- [x] \`nuxt generate\` bez chýb
- [x] Vizuálna kontrola screenshotom (dark aj light, vrátane priblíženia na product cards a trust strip)
- [x] Lighthouse: Accessibility/Best Practices/SEO 100/100/100 vo všetkých troch jazykoch (Performance 91-95)
- [x] axe-core: 0 violations (sk/cs/en × dark/light)