### PR TITLE
Design fáza 5/6: Scroll reveal animácie (useReveal)

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -241,3 +241,15 @@ a {
   background: var(--color-accent);
   flex-shrink: 0;
 }
+
+/* useReveal composable adds/removes .reveal--pending; default (no JS,
+   reduced-motion, or already-visible on load) is just the plain
+   element with no offset, so content is never hidden behind JS */
+.reveal {
+  transition: opacity 0.5s ease-out, transform 0.5s ease-out;
+}
+
+.reveal.reveal--pending {
+  opacity: 0;
+  transform: translateY(12px);
+}

--- a/app/components/ContactForm.vue
+++ b/app/components/ContactForm.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 const { t } = useI18n()
+const { target, pending } = useReveal()
 
 const form = reactive({
   name: '',
@@ -56,7 +57,7 @@ async function onSubmit() {
 
 <template>
   <section id="demo" class="contact">
-    <div class="contact__inner">
+    <div ref="target" class="contact__inner reveal" :class="{ 'reveal--pending': pending }">
       <div class="contact__copy">
         <h2>{{ t('contact.title') }}</h2>
         <p class="contact__lead">{{ t('contact.lead') }}</p>

--- a/app/components/CtaBand.vue
+++ b/app/components/CtaBand.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
 const { t } = useI18n()
+const { target, pending } = useReveal()
 </script>
 
 <template>
   <section class="cta-band">
-    <div class="cta-band__inner">
+    <div ref="target" class="cta-band__inner reveal" :class="{ 'reveal--pending': pending }">
       <div class="cta-band__copy">
         <h2>{{ t('cta_band.title') }}</h2>
         <p>{{ t('cta_band.lead') }}</p>

--- a/app/components/FaqSection.vue
+++ b/app/components/FaqSection.vue
@@ -1,12 +1,13 @@
 <script setup lang="ts">
 const { t } = useI18n()
+const { target, pending } = useReveal()
 
 const items = [1, 2, 3, 4]
 </script>
 
 <template>
   <section id="faq" class="faq">
-    <div class="faq__inner">
+    <div ref="target" class="faq__inner reveal" :class="{ 'reveal--pending': pending }">
       <h2>{{ t('faq.title') }}</h2>
 
       <div class="faq__list">

--- a/app/components/HowItWorks.vue
+++ b/app/components/HowItWorks.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 const { t } = useI18n()
+const { target, pending } = useReveal()
 
 const steps = [
   { id: 1, icon: 'tabler:search' },
@@ -11,7 +12,7 @@ const steps = [
 
 <template>
   <section id="how-it-works" class="how-it-works">
-    <div class="how-it-works__inner">
+    <div ref="target" class="how-it-works__inner reveal" :class="{ 'reveal--pending': pending }">
       <h2>{{ t('how_it_works.title') }}</h2>
 
       <ol class="how-it-works__list">

--- a/app/components/ProductCards.vue
+++ b/app/components/ProductCards.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 const { t, locale } = useI18n()
+const { target, pending } = useReveal()
 
 const localeMap: Record<string, string> = { sk: 'sk-SK', cs: 'cs-CZ', en: 'en-US' }
 
@@ -22,7 +23,7 @@ function examples(id: number) {
 
 <template>
   <section id="solutions" class="products">
-    <div class="products__inner">
+    <div ref="target" class="products__inner reveal" :class="{ 'reveal--pending': pending }">
       <h2>{{ t('products.title') }}</h2>
 
       <div id="pricing" class="products__grid">

--- a/app/components/Testimonials.vue
+++ b/app/components/Testimonials.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 const { t } = useI18n()
+const { target, pending } = useReveal()
 
 interface Testimonial {
   quote: string
@@ -16,7 +17,7 @@ const testimonials: Testimonial[] = []
 
 <template>
   <section id="references" class="testimonials">
-    <div class="testimonials__inner">
+    <div ref="target" class="testimonials__inner reveal" :class="{ 'reveal--pending': pending }">
       <h2>{{ t('testimonials.title') }}</h2>
 
       <div v-if="testimonials.length === 0" class="testimonials__placeholder">

--- a/app/components/TrustSection.vue
+++ b/app/components/TrustSection.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
 const { t } = useI18n()
+const { target, pending } = useReveal()
 </script>
 
 <template>
   <section id="approach" class="trust-section">
-    <div class="trust-section__inner">
+    <div ref="target" class="trust-section__inner reveal" :class="{ 'reveal--pending': pending }">
       <h2>{{ t('trust_section.title') }}</h2>
       <p>{{ t('trust_section.p1') }}</p>
       <p>{{ t('trust_section.p2') }}</p>

--- a/app/components/TrustStrip.vue
+++ b/app/components/TrustStrip.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 const { t } = useI18n()
+const { target, pending } = useReveal()
 
 const items = [
   { id: 1, icon: 'tabler:plug-connected' },
@@ -12,7 +13,7 @@ const items = [
 
 <template>
   <section class="trust-strip">
-    <ul class="trust-strip__list">
+    <ul ref="target" class="trust-strip__list reveal" :class="{ 'reveal--pending': pending }">
       <li v-for="item in items" :key="item.id" class="trust-strip__item">
         <Icon :name="item.icon" class="trust-strip__icon" />
         {{ t(`trust_strip.item_${item.id}`) }}

--- a/app/components/WhyProjentIQ.vue
+++ b/app/components/WhyProjentIQ.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 const { t } = useI18n()
+const { target, pending } = useReveal()
 
 const items = [
   { id: 1, icon: 'tabler:database' },
@@ -11,7 +12,7 @@ const items = [
 
 <template>
   <section id="why" class="why">
-    <div class="why__inner">
+    <div ref="target" class="why__inner reveal" :class="{ 'reveal--pending': pending }">
       <h2>{{ t('why.title') }}</h2>
 
       <ul class="why__list">

--- a/app/composables/useReveal.ts
+++ b/app/composables/useReveal.ts
@@ -1,0 +1,32 @@
+export function useReveal() {
+  const target = ref<HTMLElement | null>(null)
+  const pending = ref(false)
+
+  onMounted(() => {
+    const el = target.value
+    if (!el || !('IntersectionObserver' in window)) return
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return
+
+    // skip elements already in (or near) the viewport on load — only
+    // animate content the user actually scrolls to reveal
+    const { top } = el.getBoundingClientRect()
+    if (top < window.innerHeight * 0.9) return
+
+    pending.value = true
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry?.isIntersecting) {
+          pending.value = false
+          observer.disconnect()
+        }
+      },
+      { threshold: 0.15 }
+    )
+    observer.observe(el)
+
+    onUnmounted(() => observer.disconnect())
+  })
+
+  return { target, pending }
+}


### PR DESCRIPTION
Piata z 6 fázovaných PR pre vizuálne doladenie podľa \`.claude/projentiq_design_SPEC.md\` (časť 6: Pohyb/animácie).

## Summary
Nový composable \`useReveal\` (Intersection Observer) aplikovaný na 9 sekcií — jemný fade+slide-up (opacity 0→1, translateY 12px→0, 0.5s ease-out) pri scrolle do viewportu.

**Bezpečnostné mechanizmy (overené testami, nie len predpoklad):**
- **No-JS fallback** — \`reveal--pending\` (skrytý stav) pridáva výhradne JS po mounte. Statický HTML výstup je vždy plne viditeľný, žiadny FOUC.
- **Už viditeľné pri načítaní** — sekcie nad/blízko foldu sa vôbec neanimujú, rovno sa zobrazia (žiadne zbytočné skrývanie viditeľného obsahu).
- **\`prefers-reduced-motion: reduce\`** — observer sa vôbec nespustí, nič sa nikdy neschová.
- **Hero (LCP)** — zostáva úplne bez zmeny, žiadna \`.reveal\` trieda, vykresľuje sa okamžite, presne podľa spec.

## Test plan
- [x] \`nuxt generate\` bez chýb
- [x] No-JS: všetkých 9 \`.reveal\` prvkov má opacity 1 (curl/JS-disabled simulácia)
- [x] Normálny beh: sekcia mimo viewportu štartuje na opacity 0, po scrolle + 0.5s sa ustáli na 1
- [x] \`prefers-reduced-motion\`: žiadny prvok nikdy nejde na opacity 0
- [x] Hero nikdy neobsahuje \`.reveal\` triedu
- [x] Lighthouse: Accessibility/Best Practices/SEO 100/100/100 vo všetkých troch jazykoch (Performance 90-92)
- [x] axe-core: 0 violations po doscrollovaní na koniec stránky (sk/cs/en × dark/light)