### PR TITLE
Design fáza 6/6: Responzívny pass + dotykové ciele

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -115,6 +115,8 @@
 
 html {
   color-scheme: dark;
+  /* keeps anchor-linked section headings clear of the sticky header */
+  scroll-padding-top: 5rem;
 }
 
 html.light {

--- a/app/components/LangSwitcher.vue
+++ b/app/components/LangSwitcher.vue
@@ -28,8 +28,8 @@ const switchLocalePath = useSwitchLocalePath()
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 2.25rem;
-  height: 2.25rem;
+  min-width: 2.75rem;
+  height: 2.75rem;
   padding: 0 0.4rem;
   border: 1px solid var(--color-border);
   border-radius: 6px;

--- a/app/components/TheHeader.vue
+++ b/app/components/TheHeader.vue
@@ -3,17 +3,28 @@ const { t } = useI18n()
 const localePath = useLocalePath()
 
 const isScrolled = ref(false)
+const mobileMenuOpen = ref(false)
 
 function onScroll() {
   isScrolled.value = window.scrollY > 10
 }
 
+function closeMenu() {
+  mobileMenuOpen.value = false
+}
+
+function onKeydown(e: KeyboardEvent) {
+  if (e.key === 'Escape') mobileMenuOpen.value = false
+}
+
 onMounted(() => {
   window.addEventListener('scroll', onScroll, { passive: true })
+  window.addEventListener('keydown', onKeydown)
 })
 
 onUnmounted(() => {
   window.removeEventListener('scroll', onScroll)
+  window.removeEventListener('keydown', onKeydown)
 })
 </script>
 
@@ -22,10 +33,22 @@ onUnmounted(() => {
     <div class="site-header__inner">
       <NuxtLink :to="localePath('index')" class="site-header__logo">Projent<span class="site-header__logo-accent">IQ</span></NuxtLink>
 
-      <nav class="site-header__nav" :aria-label="t('nav.main_label')">
-        <a href="#solutions">{{ t('nav.solutions') }}</a>
-        <a href="#pricing">{{ t('nav.pricing') }}</a>
-        <a href="#references">{{ t('nav.references') }}</a>
+      <button
+        type="button"
+        class="site-header__menu-toggle"
+        :aria-label="mobileMenuOpen ? t('nav.menu_close') : t('nav.menu_open')"
+        :aria-expanded="mobileMenuOpen"
+        aria-controls="site-header-nav"
+        @click="mobileMenuOpen = !mobileMenuOpen"
+      >
+        <Icon v-show="mobileMenuOpen" name="tabler:x" aria-hidden="true" />
+        <Icon v-show="!mobileMenuOpen" name="tabler:menu-2" aria-hidden="true" />
+      </button>
+
+      <nav id="site-header-nav" class="site-header__nav" :class="{ 'is-open': mobileMenuOpen }" :aria-label="t('nav.main_label')">
+        <a href="#solutions" @click="closeMenu">{{ t('nav.solutions') }}</a>
+        <a href="#pricing" @click="closeMenu">{{ t('nav.pricing') }}</a>
+        <a href="#references" @click="closeMenu">{{ t('nav.references') }}</a>
       </nav>
 
       <div class="site-header__actions">
@@ -125,5 +148,74 @@ onUnmounted(() => {
   padding: 0.5rem 1rem;
   font-size: 0.9rem;
   box-shadow: none;
+}
+
+.site-header__menu-toggle {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  background: none;
+  border: 1px solid var(--color-border);
+  border-radius: var(--r-sm);
+  color: var(--color-text);
+  cursor: pointer;
+}
+
+.site-header__menu-toggle:hover {
+  border-color: var(--color-accent);
+}
+
+.site-header__menu-toggle :deep(svg) {
+  width: 20px;
+  height: 20px;
+}
+
+@media (max-width: 56rem) {
+  .site-header__menu-toggle {
+    display: inline-flex;
+  }
+
+  .site-header__actions {
+    flex-basis: 100%;
+    flex-wrap: wrap;
+    row-gap: 0.5rem;
+    justify-content: flex-end;
+  }
+
+  .site-header__nav {
+    display: none;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    flex-direction: column;
+    gap: 0;
+    padding: 0.25rem 1.5rem 1rem;
+    background: var(--color-surface-1);
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  .site-header__nav.is-open {
+    display: flex;
+  }
+
+  .site-header__nav a {
+    padding: 0.85rem 0;
+    font-size: 1rem;
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  .site-header__nav a:last-child {
+    border-bottom: none;
+  }
+}
+
+@media (max-width: 26rem) {
+  .site-header__actions .btn-primary {
+    padding: 0.5rem 0.75rem;
+    font-size: 0.85rem;
+  }
 }
 </style>

--- a/app/components/ThemeToggle.vue
+++ b/app/components/ThemeToggle.vue
@@ -23,8 +23,8 @@ function toggle() {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 2.25rem;
-  height: 2.25rem;
+  width: 2.75rem;
+  height: 2.75rem;
   background: none;
   border: 1px solid var(--color-border);
   border-radius: 6px;

--- a/i18n/locales/cs.json
+++ b/i18n/locales/cs.json
@@ -4,7 +4,9 @@
     "solutions": "Řešení",
     "pricing": "Ceník",
     "references": "Reference",
-    "cta_demo": "Vyžádat demo"
+    "cta_demo": "Vyžádat demo",
+    "menu_open": "Otevřít menu",
+    "menu_close": "Zavřít menu"
   },
   "meta": {
     "title": "Projentiq – AI agenti, znalostní systémy a automatizace procesů",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -4,7 +4,9 @@
     "solutions": "Solutions",
     "pricing": "Pricing",
     "references": "References",
-    "cta_demo": "Request a demo"
+    "cta_demo": "Request a demo",
+    "menu_open": "Open menu",
+    "menu_close": "Close menu"
   },
   "meta": {
     "title": "Projentiq – AI agents, knowledge systems, and process automation",

--- a/i18n/locales/sk.json
+++ b/i18n/locales/sk.json
@@ -4,7 +4,9 @@
     "solutions": "Riešenia",
     "pricing": "Ceny",
     "references": "Referencie",
-    "cta_demo": "Požiadať o demo"
+    "cta_demo": "Požiadať o demo",
+    "menu_open": "Otvoriť menu",
+    "menu_close": "Zatvoriť menu"
   },
   "meta": {
     "title": "Projentiq – AI agenti, znalostné systémy a automatizácia procesov",


### PR DESCRIPTION
Posledná z 6 fázovaných PR pre vizuálne doladenie podľa \`.claude/projentiq_design_SPEC.md\` (časti 7-9: Responzív, Prístupnosť, Výkon).

## Summary
Prešiel som screenshotmi všetky sekcie pri 1280/1024/896/768/660/600/375/320px (dark aj light) a opravil to, čo sa reálne rozbíjalo — nielen kozmeticky doladil podľa špekulácie.

**Header — mobilné hamburger menu** (spec: "skry textovú nav za toggle, ponechaj logo + CTA + prepínače")
- Pod ≤56rem sa nav skrýva za hamburger, logo + jazyk + téma + CTA ostávajú vždy viditeľné
- Pôvodný layout (bez tohto rozdelenia) sa pri ~660-768px rozpadal na neusporiadané viacriadkové zalamovanie — overené screenshotom pred/po
- \`.site-header__actions\` má vlastný flex-wrap ako poistku proti horizontálnemu pretečeniu pri veľmi úzkych šírkach (320px)
- Dropdown s hairline riadkami, Escape zatvára, klik na link zatvára, aria-expanded/aria-controls

**Bug objavený počas testovania**: ikona zatvorenia (✕) sa v statickom builde nikdy nezobrazila — renderovala sa len cez \`v-if\` pri \`mobileMenuOpen === true\`, ale ten stav nikdy nenastane počas SSR prerenderu, takže sa nikdy nezapiekla do statického HTML. Runtime fetch na \`/api/_nuxt_icon/...\` v statickom hostingu neexistuje → 404, ikona zostala prázdna. Fix: \`v-show\` namiesto \`v-if\`/\`v-else\` (obe ikony vždy v DOM, jedna cez \`display:none\`), takže obe sa SSR-prerenderujú.

**Dotykové ciele** (spec: min. 44×44px) — LangSwitcher položky a ThemeToggle boli 36×36px → 44×44px.

**Kotvové odkazy** — \`scroll-padding-top\` na \`<html>\`, inak po kliku na "Riešenia"/"Ceny" zostal nadpis sekcie schovaný presne pod sticky headerom.

## Test plan
- [x] \`nuxt generate\` bez chýb
- [x] 0 horizontálneho pretečenia pri 320-1280px (programovo zmerané)
- [x] Obe toggle ikony potvrdené priamo v statickom HTML (nie len runtime fetch)
- [x] Escape zatvára mobilné menu, klik na link tiež
- [x] Dotykové ciele 44×44px zmerané priamo v DOM
- [x] Lighthouse: Accessibility/Best Practices/SEO 100/100/100 vo všetkých troch jazykoch (Performance 92-95)
- [x] axe-core: 0 violations (desktop sk/cs/en × dark/light + mobile s otvoreným menu)

---

Toto je posledná fáza dizajnového doladenia — po mergnutí je celý \`.claude/projentiq_design_SPEC.md\` implementovaný.