### PR TITLE
Prepínač jazykov ako kompaktný dropdown

### DIFF
--- a/app/components/LangSwitcher.vue
+++ b/app/components/LangSwitcher.vue
@@ -1,51 +1,138 @@
 <script setup lang="ts">
 const { locale, locales, t } = useI18n()
 const switchLocalePath = useSwitchLocalePath()
+
+const isOpen = ref(false)
+const root = ref<HTMLElement | null>(null)
+
+const current = computed(() => locales.value.find((l) => l.code === locale.value))
+
+function toggle() {
+  isOpen.value = !isOpen.value
+}
+
+function close() {
+  isOpen.value = false
+}
+
+function onClickOutside(e: MouseEvent) {
+  if (root.value && !root.value.contains(e.target as Node)) close()
+}
+
+function onKeydown(e: KeyboardEvent) {
+  if (e.key === 'Escape') close()
+}
+
+onMounted(() => {
+  document.addEventListener('click', onClickOutside)
+  document.addEventListener('keydown', onKeydown)
+})
+
+onUnmounted(() => {
+  document.removeEventListener('click', onClickOutside)
+  document.removeEventListener('keydown', onKeydown)
+})
 </script>
 
 <template>
-  <nav class="lang-switcher" :aria-label="t('lang.switch_label')">
-    <NuxtLink
-      v-for="l in locales"
-      :key="l.code"
-      :to="switchLocalePath(l.code)"
-      class="lang-switcher__item"
-      :class="{ 'is-active': l.code === locale }"
-      :aria-current="l.code === locale ? 'page' : undefined"
+  <div ref="root" class="lang-switcher">
+    <button
+      type="button"
+      class="lang-switcher__trigger"
+      aria-haspopup="true"
+      :aria-expanded="isOpen"
+      :aria-label="t('lang.switch_label')"
+      @click="toggle"
     >
-      {{ l.code.toUpperCase() }}
-    </NuxtLink>
-  </nav>
+      {{ current?.code.toUpperCase() }}
+      <Icon name="tabler:chevron-down" class="lang-switcher__chevron" :class="{ 'is-open': isOpen }" aria-hidden="true" />
+    </button>
+
+    <ul v-if="isOpen" class="lang-switcher__menu" role="listbox" :aria-label="t('lang.switch_label')">
+      <li v-for="l in locales" :key="l.code" role="presentation">
+        <NuxtLink
+          :to="switchLocalePath(l.code)"
+          class="lang-switcher__option"
+          :class="{ 'is-active': l.code === locale }"
+          role="option"
+          :aria-selected="l.code === locale"
+          @click="close"
+        >
+          {{ l.name }}
+        </NuxtLink>
+      </li>
+    </ul>
+  </div>
 </template>
 
 <style scoped>
 .lang-switcher {
-  display: inline-flex;
-  gap: 0.25rem;
+  position: relative;
 }
 
-.lang-switcher__item {
+.lang-switcher__trigger {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  gap: 0.3rem;
   min-width: 2.75rem;
   height: 2.75rem;
-  padding: 0 0.4rem;
+  padding: 0 0.65rem;
+  background: none;
   border: 1px solid var(--color-border);
-  border-radius: 6px;
+  border-radius: var(--r-sm);
   color: var(--color-text-muted);
   font-size: 0.8rem;
-  text-decoration: none;
+  font-weight: var(--fw-semibold);
+  cursor: pointer;
 }
 
-.lang-switcher__item:hover {
+.lang-switcher__trigger:hover {
   border-color: var(--color-accent);
   color: var(--color-text);
 }
 
-.lang-switcher__item.is-active {
-  border-color: var(--color-accent);
+.lang-switcher__chevron {
+  width: 14px;
+  height: 14px;
+  transition: transform 0.15s ease;
+}
+
+.lang-switcher__chevron.is-open {
+  transform: rotate(180deg);
+}
+
+.lang-switcher__menu {
+  position: absolute;
+  top: calc(100% + 0.4rem);
+  right: 0;
+  min-width: 9rem;
+  margin: 0;
+  padding: 0.35rem;
+  list-style: none;
+  background: var(--color-surface-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--r-md);
+  box-shadow: var(--sh-lg);
+  z-index: 10;
+}
+
+.lang-switcher__option {
+  display: block;
+  padding: 0.75rem 0.65rem;
+  border-radius: var(--r-sm);
+  color: var(--color-text-muted);
+  font-size: 0.9rem;
+  text-decoration: none;
+}
+
+.lang-switcher__option:hover {
+  background: var(--color-surface-3);
+  color: var(--color-text);
+}
+
+.lang-switcher__option.is-active {
   color: var(--color-accent);
-  font-weight: 600;
+  font-weight: var(--fw-semibold);
 }
 </style>

--- a/app/components/TheHeader.vue
+++ b/app/components/TheHeader.vue
@@ -33,18 +33,6 @@ onUnmounted(() => {
     <div class="site-header__inner">
       <NuxtLink :to="localePath('index')" class="site-header__logo">Projent<span class="site-header__logo-accent">IQ</span></NuxtLink>
 
-      <button
-        type="button"
-        class="site-header__menu-toggle"
-        :aria-label="mobileMenuOpen ? t('nav.menu_close') : t('nav.menu_open')"
-        :aria-expanded="mobileMenuOpen"
-        aria-controls="site-header-nav"
-        @click="mobileMenuOpen = !mobileMenuOpen"
-      >
-        <Icon v-show="mobileMenuOpen" name="tabler:x" aria-hidden="true" />
-        <Icon v-show="!mobileMenuOpen" name="tabler:menu-2" aria-hidden="true" />
-      </button>
-
       <nav id="site-header-nav" class="site-header__nav" :class="{ 'is-open': mobileMenuOpen }" :aria-label="t('nav.main_label')">
         <a href="#solutions" @click="closeMenu">{{ t('nav.solutions') }}</a>
         <a href="#pricing" @click="closeMenu">{{ t('nav.pricing') }}</a>
@@ -56,6 +44,17 @@ onUnmounted(() => {
         <LangSwitcher />
         <ThemeToggle />
         <a href="#demo" class="site-header__cta btn-primary">{{ t('nav.cta_demo') }}</a>
+        <button
+          type="button"
+          class="site-header__menu-toggle"
+          :aria-label="mobileMenuOpen ? t('nav.menu_close') : t('nav.menu_open')"
+          :aria-expanded="mobileMenuOpen"
+          aria-controls="site-header-nav"
+          @click="mobileMenuOpen = !mobileMenuOpen"
+        >
+          <Icon v-show="mobileMenuOpen" name="tabler:x" aria-hidden="true" />
+          <Icon v-show="!mobileMenuOpen" name="tabler:menu-2" aria-hidden="true" />
+        </button>
       </div>
     </div>
   </header>

--- a/app/components/TheHeader.vue
+++ b/app/components/TheHeader.vue
@@ -49,12 +49,13 @@ onUnmounted(() => {
         <a href="#solutions" @click="closeMenu">{{ t('nav.solutions') }}</a>
         <a href="#pricing" @click="closeMenu">{{ t('nav.pricing') }}</a>
         <a href="#references" @click="closeMenu">{{ t('nav.references') }}</a>
+        <a href="#demo" class="site-header__nav-cta btn-primary" @click="closeMenu">{{ t('nav.cta_demo') }}</a>
       </nav>
 
       <div class="site-header__actions">
         <LangSwitcher />
         <ThemeToggle />
-        <a href="#demo" class="btn-primary">{{ t('nav.cta_demo') }}</a>
+        <a href="#demo" class="site-header__cta btn-primary">{{ t('nav.cta_demo') }}</a>
       </div>
     </div>
   </header>
@@ -150,6 +151,10 @@ onUnmounted(() => {
   box-shadow: none;
 }
 
+.site-header__nav-cta {
+  display: none;
+}
+
 .site-header__menu-toggle {
   display: none;
   align-items: center;
@@ -178,10 +183,11 @@ onUnmounted(() => {
   }
 
   .site-header__actions {
-    flex-basis: 100%;
-    flex-wrap: wrap;
-    row-gap: 0.5rem;
-    justify-content: flex-end;
+    gap: 0.5rem;
+  }
+
+  .site-header__cta {
+    display: none;
   }
 
   .site-header__nav {
@@ -207,15 +213,12 @@ onUnmounted(() => {
     border-bottom: 1px solid var(--color-border);
   }
 
-  .site-header__nav a:last-child {
+  .site-header__nav .site-header__nav-cta {
+    display: flex;
+    justify-content: center;
+    margin-top: 0.75rem;
+    padding: 0.7rem 0;
     border-bottom: none;
-  }
-}
-
-@media (max-width: 26rem) {
-  .site-header__actions .btn-primary {
-    padding: 0.5rem 0.75rem;
-    font-size: 0.85rem;
   }
 }
 </style>


### PR DESCRIPTION
PR #28 sa medzitým mergol skôr, než stihol tento commit prejsť review — tento PR obsahuje len ten jeden zvyšný commit (LangSwitcher).

## Summary
Tri samostatné 44×44px tlačidlá (SK/CS/EN) vždy viditeľné v headeri zaberali zbytočne veľa miesta a pôsobili ťažkopádne, najmä v kombinácii s ostatnými header prvkami na mobile. Nahradené jedným trigger tlačidlom (aktuálny jazyk + chevron), ktoré po kliku rozbalí dropdown so všetkými mutáciami (plné názvy, aktívna zvýraznená accent farbou).

- Zatvára sa kliknutím mimo, klávesou Escape, alebo výberom jazyka
- \`role="listbox"\`/\`"option"\` + \`aria-expanded\`/\`aria-haspopup\` na triggeri
- Trigger zostáva 44px vysoký (dotykový cieľ), položky v menu majú ~44px výšku

## Test plan
- [x] \`nuxt generate\` bez chýb
- [x] axe-core: 0 violations (dark aj light, s otvoreným menu) — vrátane opraveného \`aria-input-field-name\` na \`role="listbox"\` elemente
- [x] 0 horizontálneho pretečenia na mobile (375px) s otvoreným menu
- [x] Trigger aj položky menu majú ≥44×44px dotykový cieľ
- [x] Lighthouse Accessibility 100