### PR TITLE
Hero panel: Pred/Po (Before/After)

### DIFF
--- a/.claude/projentiq_hero_SPEC_v2.md
+++ b/.claude/projentiq_hero_SPEC_v2.md
@@ -1,0 +1,260 @@
+# Spec: ProjentIQ — Hero sekcia (variant A: Pred / Po) — v2
+
+> AKTUALIZOVANÁ verzia, zladená so súčasným kódom v repozitári.
+> Nahrádza projentiq_hero_SPEC.md. Plán pred kódom — prečítaj celé.
+>
+> Stav kódu (jún 2026): dizajnový systém, tokeny, glow, gradient nadpis, panel
+> s tieňom, mono captions, status chipy aj `useReveal` composable sú už hotové.
+> Hero copy a layout fungujú. JEDINÁ vecná zmena v tomto spec = prerobiť OBSAH
+> pravého panela z dnešnej „zmiešanej" verzie na vizuál Pred / Po.
+
+---
+
+## 0. Čo NEMENÍŠ (už je hotové a správne)
+
+- `.hero`, `.hero__bg` (glow + mriežka cez `::after`), `.hero__inner`,
+  `.hero__copy`, `.hero__visual` — layout a pozadie ostávajú.
+- Eyebrow, H1 s `.hero__title-gradient`, lead, rotátor (`.hero__rotator`),
+  micro-trust (`.hero__trust-microcopy`) — ostávajú.
+- CTA tlačidlá: `nav.cta_demo` („Požiadať o demo") + `hero.cta_contact`
+  („Kontaktovať nás"). **NEMENIŤ** — celá stránka je na nich zjednotená.
+- Tokeny (`--color-surface-1`, `--color-border`, `--r-lg`, `--sh-lg`,
+  `--hairline-top`, `--font-mono`, `--fs-xs`, `--color-success-soft`,
+  `--color-accent-soft`, `--color-accent-border`…) — používaj existujúce.
+- Ikony: cez `<Icon name="tabler:..." />` (nuxt-icon), NIE `<i class="ti">`.
+
+---
+
+## 1. Jediná zmena: pravý panel → Pred / Po
+
+### Čo nahrádzaš
+V `HeroSection.vue` zmaž blok `panelItems` (script) a celý `.hero-panel`
+markup (4 zmiešané riadky: agent/vyhľadávanie/automatizácia/dokument) vnútri
+`.hero__visual`. Nahraď ho Pred/Po panelom nižšie.
+
+Dôvod: dnešný panel mieša všetky tri služby do jedného zoznamu a návštevník za
+5 sekúnd nepochopí, čo dostane. Pred/Po ukáže bolesť (vľavo) a úľavu (vpravo)
+bez čítania.
+
+### Nový script blok
+```ts
+const baRows = [
+  {
+    labelKey: 'hero.panel.invoices_label',
+    beforeKey: 'hero.panel.invoices_before', beforeMetaKey: 'hero.panel.invoices_before_meta',
+    afterKey:  'hero.panel.invoices_after',  afterMetaKey:  'hero.panel.invoices_after_meta'
+  },
+  {
+    labelKey: 'hero.panel.contracts_label',
+    beforeKey: 'hero.panel.contracts_before', beforeMetaKey: 'hero.panel.contracts_before_meta',
+    afterKey:  'hero.panel.contracts_after',  afterMetaKey:  'hero.panel.contracts_after_meta'
+  },
+  {
+    labelKey: 'hero.panel.orders_label',
+    beforeKey: 'hero.panel.orders_before', beforeMetaKey: 'hero.panel.orders_before_meta',
+    afterKey:  'hero.panel.orders_after',  afterMetaKey:  'hero.panel.orders_after_meta'
+  }
+]
+```
+> Rotátor a jeho logiku (`rotatingPhrases`, `startRotation`…) PONECHAJ.
+
+### Nový markup (vnútri `.hero__visual`, ktoré ostáva `aria-hidden="true"`)
+```html
+<div class="hero-ba">
+  <div class="hero-ba__header">
+    <span class="hero-ba__tab hero-ba__tab--before">{{ t('hero.panel.tab_before') }}</span>
+    <span class="hero-ba__tab hero-ba__tab--after">{{ t('hero.panel.tab_after') }}</span>
+  </div>
+
+  <div class="hero-ba__grid">
+    <div class="hero-ba__col hero-ba__col--before">
+      <div v-for="(row, i) in baRows" :key="`b-${i}`" class="hero-ba__row hero-ba__row--before">
+        <p class="hero-ba__label">{{ t(row.labelKey) }}</p>
+        <p class="hero-ba__text">{{ t(row.beforeKey) }}</p>
+        <p class="hero-ba__meta">{{ t(row.beforeMetaKey) }}</p>
+      </div>
+    </div>
+    <div class="hero-ba__col hero-ba__col--after">
+      <div v-for="(row, i) in baRows" :key="`a-${i}`" class="hero-ba__row hero-ba__row--after">
+        <p class="hero-ba__label">{{ t(row.labelKey) }}</p>
+        <p class="hero-ba__text">{{ t(row.afterKey) }}</p>
+        <p class="hero-ba__meta">{{ t(row.afterMetaKey) }}</p>
+      </div>
+    </div>
+  </div>
+
+  <div class="hero-ba__footer">
+    <Icon name="tabler:info-circle" class="hero-ba__footer-icon" />
+    {{ t('hero.panel.disclaimer') }}
+  </div>
+</div>
+```
+
+### Štýl (scoped, používa existujúce tokeny)
+```css
+.hero-ba {
+  background: var(--color-surface-1);
+  border: 1px solid var(--color-border);
+  border-radius: var(--r-lg);
+  overflow: hidden;
+  box-shadow: var(--sh-lg), var(--hairline-top);
+}
+.hero-ba__header {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  border-bottom: 1px solid var(--color-border);
+}
+.hero-ba__tab {
+  padding: 0.6rem 1rem;
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  font-weight: var(--fw-semibold);
+  text-align: center;
+  letter-spacing: 0.04em;
+}
+.hero-ba__tab--before { background: var(--color-surface-2); color: var(--color-text-subtle); }
+.hero-ba__tab--after  { background: var(--color-accent-soft); color: var(--color-accent);
+                        border-left: 1px solid var(--color-accent-border); }
+
+.hero-ba__grid { display: grid; grid-template-columns: 1fr 1fr; }
+.hero-ba__col { padding: 0.875rem; }
+.hero-ba__col--before { border-right: 1px solid var(--color-border); }
+
+.hero-ba__row {
+  padding: 0.625rem;
+  border-radius: var(--r-sm);
+  margin-bottom: 0.5rem;
+  border: 1px solid var(--color-border);
+}
+.hero-ba__row:last-child { margin-bottom: 0; }
+.hero-ba__row--before { background: var(--color-surface-2); }
+.hero-ba__row--after  { background: var(--color-accent-soft); border-color: var(--color-accent-border); }
+
+.hero-ba__label {
+  margin: 0 0 0.25rem;
+  font-family: var(--font-mono);
+  font-size: 0.65rem;
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-wide);
+}
+.hero-ba__row--before .hero-ba__label { color: var(--color-text-subtle); }
+.hero-ba__row--after  .hero-ba__label { color: var(--color-accent); }
+
+.hero-ba__text {
+  margin: 0;
+  font-size: 0.8rem;
+  font-weight: var(--fw-medium);
+  line-height: 1.35;
+  color: var(--color-text-muted);
+}
+.hero-ba__row--after .hero-ba__text { color: var(--color-text); }
+
+.hero-ba__meta {
+  margin: 0.2rem 0 0;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+}
+.hero-ba__row--before .hero-ba__meta { color: var(--color-text-subtle); }
+.hero-ba__row--after  .hero-ba__meta { color: var(--color-success); }
+
+.hero-ba__footer {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.55rem 0.875rem;
+  border-top: 1px solid var(--color-border);
+  background: var(--color-surface-2);
+  font-family: var(--font-mono);
+  font-size: 0.65rem;
+  color: var(--color-text-subtle);
+}
+.hero-ba__footer-icon { width: 14px; height: 14px; color: var(--color-accent); flex-shrink: 0; }
+
+/* Responzív: panel zmizne na mobile (je dekoratívny, aria-hidden) */
+@media (max-width: 40rem) {
+  .hero__visual { display: none; }
+}
+```
+
+---
+
+## 2. i18n kľúče na DOPLNENIE (sk.json, cs.json, en.json)
+
+Pridaj pod existujúci `hero.panel` blok (staré kľúče panela `kind_*`, `row_*`,
+`status_*`, `live_badge`, `panel_caption` môžeš zmazať — už ich netreba):
+
+```json
+"hero": {
+  "panel": {
+    "tab_before": "← Predtým",
+    "tab_after": "Potom →",
+    "disclaimer": "Časy sú ilustračné — reálne výsledky závisia od procesu",
+
+    "invoices_label": "Faktúry",
+    "invoices_before": "Ručný prepis do účtovníctva",
+    "invoices_before_meta": "~3 hod./deň",
+    "invoices_after": "AI vytiahne údaje, vy schválite",
+    "invoices_after_meta": "~8 sek./faktúra",
+
+    "contracts_label": "Zmluvy",
+    "contracts_before": "Hľadanie v zdieľanom disku",
+    "contracts_before_meta": "~20 min./dotaz",
+    "contracts_after": "Asistent odpovie s citáciou",
+    "contracts_after_meta": "~4 sek./dotaz",
+
+    "orders_label": "Objednávky",
+    "orders_before": "Ručné zadávanie z e-mailov",
+    "orders_before_meta": "každý deň",
+    "orders_after": "Agent spracuje a zaeviduje",
+    "orders_after_meta": "automaticky"
+  }
+}
+```
+> Preklady do cs.json a en.json dorob ekvivalentne (ponechaj „←/→" symboly).
+
+---
+
+## 3. Voliteľné (NEpovinné) — len ak chceš
+
+Tieto NEROB automaticky, sú to návrhy na zváženie:
+
+- **H1.** Dnešné „AI systémy, ktoré pracujú s vašimi dátami." je trochu
+  produktové. Partnerskejšia alternatíva: „Zavedieme AI do vašej firmy. Od návrhu
+  po prevádzku." (highlight = druhá veta). Rozhodni sa sám — ak meníš, uprav
+  `hero.title_main` + `hero.title_highlight`.
+- **Rotátor** nech rotuje cez tri OBLASTI služieb (agenti / znalostné bázy /
+  automatizácia), nie cez jeden príklad extrakcie — aby neduplikoval panel.
+
+---
+
+## 4. Prístupnosť a výkon (zachovať)
+
+- `.hero__visual` ostáva `aria-hidden="true"` — panel je dekoratívny, rovnaká
+  informácia je v copy texte vľavo.
+- H1 a lead sa NEanimujú pri vstupe (LCP). Ak je na nich `useReveal`/fade, odober.
+  Panel (vpravo) sa animovať reveal-om môže.
+- Kontrast textu AA v oboch témach — over `--color-text-subtle` na `surface-2`.
+- `prefers-reduced-motion` rešpektuj (rotátor a pulz už to majú).
+
+---
+
+## 5. Čo NErobiť
+
+- Nemeniť CTA tlačidlá ani ich kľúče (`nav.cta_demo`, `hero.cta_contact`).
+- Nevytvárať nové i18n kľúče pre nadpis/lead — tie existujú (`title_main`,
+  `title_highlight`, `lead`, `eyebrow`, `trust_microcopy`).
+- Nerobiť Pred/Po záložky klikateľnými — je to vizuálna metafora, nie tab komponent.
+- Neanimovať H1 (LCP).
+- Nepoužívať `<i class="ti">` — projekt má nuxt-icon (`<Icon name="tabler:...">`).
+- Disclaimer footer ponechať, kým nemáš reálne čísla od klienta.
+
+---
+
+## 6. Poradie implementácie
+
+1. Doplň/uprav i18n kľúče `hero.panel.*` (časť 2) vo všetkých 3 jazykoch.
+2. V `HeroSection.vue`: zmaž `panelItems` + starý `.hero-panel` markup.
+3. Pridaj `baRows` + nový `.hero-ba` markup a scoped štýly (časť 1).
+4. Responzív + over LCP (H1 bez animácie) + kontrast.
+5. (Voliteľné) uprav rotátor/H1 podľa časti 3.
+```

--- a/app/components/HeroSection.vue
+++ b/app/components/HeroSection.vue
@@ -1,11 +1,22 @@
 <script setup lang="ts">
 const { t } = useI18n()
 
-const panelItems = [
-  { icon: 'tabler:robot', kindKey: 'hero.panel.kind_agent', textKey: 'hero.panel.row_agent', statusKey: 'hero.panel.status_done' },
-  { icon: 'tabler:search', kindKey: 'hero.panel.kind_search', textKey: 'hero.panel.row_search', statusKey: 'hero.panel.status_done' },
-  { icon: 'tabler:settings-automation', kindKey: 'hero.panel.kind_automation', textKey: 'hero.panel.row_automation', statusKey: 'hero.panel.status_review' },
-  { icon: 'tabler:file-text', kindKey: 'hero.panel.kind_document', textKey: 'hero.panel.row_document', statusKey: 'hero.panel.status_done' }
+const baRows = [
+  {
+    labelKey: 'hero.panel.invoices_label',
+    beforeKey: 'hero.panel.invoices_before', beforeMetaKey: 'hero.panel.invoices_before_meta',
+    afterKey:  'hero.panel.invoices_after',  afterMetaKey:  'hero.panel.invoices_after_meta'
+  },
+  {
+    labelKey: 'hero.panel.contracts_label',
+    beforeKey: 'hero.panel.contracts_before', beforeMetaKey: 'hero.panel.contracts_before_meta',
+    afterKey:  'hero.panel.contracts_after',  afterMetaKey:  'hero.panel.contracts_after_meta'
+  },
+  {
+    labelKey: 'hero.panel.orders_label',
+    beforeKey: 'hero.panel.orders_before', beforeMetaKey: 'hero.panel.orders_before_meta',
+    afterKey:  'hero.panel.orders_after',  afterMetaKey:  'hero.panel.orders_after_meta'
+  }
 ]
 
 const rotatingPhrases = computed(() => [
@@ -59,30 +70,33 @@ onUnmounted(stopRotation)
       </div>
 
       <div class="hero__visual" aria-hidden="true">
-        <div class="hero-panel">
-          <div class="hero-panel__header">
-            <p class="hero-panel__caption">{{ t('hero.panel_caption') }}</p>
-            <span class="hero-panel__live">
-              <span class="hero-panel__live-dot" />
-              {{ t('hero.panel.live_badge') }}
-            </span>
+        <div class="hero-ba">
+          <div class="hero-ba__header">
+            <span class="hero-ba__tab hero-ba__tab--before">{{ t('hero.panel.tab_before') }}</span>
+            <span class="hero-ba__tab hero-ba__tab--after">{{ t('hero.panel.tab_after') }}</span>
           </div>
-          <ul class="hero-panel__list">
-            <li v-for="(item, i) in panelItems" :key="i" class="hero-panel__row">
-              <Icon :name="item.icon" class="hero-panel__icon" />
-              <span class="hero-panel__body">
-                <span class="hero-panel__kind">{{ t(item.kindKey) }}</span>
-                <span class="hero-panel__text">{{ t(item.textKey) }}</span>
-              </span>
-              <span
-                class="hero-panel__status"
-                :class="{ 'is-review': item.statusKey.endsWith('status_review') }"
-              >
-                <span class="hero-panel__status-dot" />
-                {{ t(item.statusKey) }}
-              </span>
-            </li>
-          </ul>
+
+          <div class="hero-ba__grid">
+            <div class="hero-ba__col hero-ba__col--before">
+              <div v-for="(row, i) in baRows" :key="`b-${i}`" class="hero-ba__row hero-ba__row--before">
+                <p class="hero-ba__label">{{ t(row.labelKey) }}</p>
+                <p class="hero-ba__text">{{ t(row.beforeKey) }}</p>
+                <p class="hero-ba__meta">{{ t(row.beforeMetaKey) }}</p>
+              </div>
+            </div>
+            <div class="hero-ba__col hero-ba__col--after">
+              <div v-for="(row, i) in baRows" :key="`a-${i}`" class="hero-ba__row hero-ba__row--after">
+                <p class="hero-ba__label">{{ t(row.labelKey) }}</p>
+                <p class="hero-ba__text">{{ t(row.afterKey) }}</p>
+                <p class="hero-ba__meta">{{ t(row.afterMetaKey) }}</p>
+              </div>
+            </div>
+          </div>
+
+          <div class="hero-ba__footer">
+            <Icon name="tabler:info-circle" class="hero-ba__footer-icon" />
+            {{ t('hero.panel.disclaimer') }}
+          </div>
         </div>
       </div>
     </div>
@@ -195,155 +209,143 @@ onUnmounted(stopRotation)
   color: var(--color-text-muted);
 }
 
-.hero-panel {
+.hero-ba {
   background: var(--color-surface-1);
   border: 1px solid var(--color-border);
   border-radius: var(--r-lg);
-  padding: 1.25rem;
+  overflow: hidden;
   box-shadow: var(--sh-lg), var(--hairline-top);
 }
 
-.hero-panel__header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
-  margin: 0 0 1rem;
+.hero-ba__header {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  border-bottom: 1px solid var(--color-border);
 }
 
-.hero-panel__caption {
-  margin: 0;
-  font-family: var(--font-mono);
-  font-size: var(--fs-xs);
-  text-transform: uppercase;
-  letter-spacing: var(--tracking-wide);
-  color: var(--color-text-muted);
-}
-
-.hero-panel__live {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  padding: 0.2rem 0.55rem;
-  border-radius: var(--r-full);
-  background: var(--color-success-soft);
-  color: var(--color-success);
+.hero-ba__tab {
+  padding: 0.6rem 1rem;
   font-family: var(--font-mono);
   font-size: var(--fs-xs);
   font-weight: var(--fw-semibold);
-  white-space: nowrap;
+  text-align: center;
+  letter-spacing: 0.04em;
 }
 
-.hero-panel__live-dot {
-  width: 0.4rem;
-  height: 0.4rem;
-  border-radius: 50%;
-  background: currentColor;
-  animation: hero-pulse 1.8s ease-in-out infinite;
+.hero-ba__tab--before {
+  background: var(--color-surface-2);
+  color: var(--color-text-muted);
 }
 
-@keyframes hero-pulse {
-  0%, 100% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0.35;
-  }
+.hero-ba__tab--after {
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+  border-left: 1px solid var(--color-accent-border);
 }
 
-.hero-panel__list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-}
-
-.hero-panel__row {
+.hero-ba__grid {
   display: grid;
-  grid-template-columns: auto 1fr auto;
-  gap: 0.75rem;
-  align-items: center;
-  padding: 0.65rem 0.5rem;
-  border-bottom: 1px solid var(--color-border);
+  grid-template-columns: 1fr 1fr;
+}
+
+.hero-ba__col {
+  padding: 0.875rem;
+}
+
+.hero-ba__col--before {
+  border-right: 1px solid var(--color-border);
+}
+
+.hero-ba__row {
+  padding: 0.625rem;
   border-radius: var(--r-sm);
-  font-size: 0.85rem;
-  transition: background-color 0.15s ease;
+  margin-bottom: 0.5rem;
+  border: 1px solid var(--color-border);
 }
 
-.hero-panel__row:last-child {
-  border-bottom: none;
+.hero-ba__row:last-child {
+  margin-bottom: 0;
 }
 
-.hero-panel__row:hover {
+.hero-ba__row--before {
   background: var(--color-surface-2);
 }
 
-.hero-panel__icon {
-  width: 18px;
-  height: 18px;
-  color: var(--color-accent);
-  flex-shrink: 0;
+.hero-ba__row--after {
+  background: var(--color-accent-soft);
+  border-color: var(--color-accent-border);
 }
 
-.hero-panel__body {
-  display: flex;
-  flex-direction: column;
-  gap: 0.1rem;
-  min-width: 0;
-}
-
-.hero-panel__kind {
+.hero-ba__label {
+  margin: 0 0 0.25rem;
   font-family: var(--font-mono);
-  font-size: var(--fs-xs);
+  font-size: 0.65rem;
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-wide);
+}
+
+.hero-ba__row--before .hero-ba__label {
   color: var(--color-text-muted);
 }
 
-.hero-panel__text {
-  font-weight: var(--fw-medium);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.hero-panel__status {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  padding: 0.2rem 0.5rem;
-  border-radius: var(--r-full);
-  background: var(--color-success-soft);
-  color: var(--color-success);
-  font-size: 0.75rem;
-  font-weight: var(--fw-semibold);
-  white-space: nowrap;
-}
-
-.hero-panel__status-dot {
-  width: 0.35rem;
-  height: 0.35rem;
-  border-radius: 50%;
-  background: currentColor;
-  flex-shrink: 0;
-}
-
-.hero-panel__status.is-review {
-  background: var(--color-accent-soft);
+.hero-ba__row--after .hero-ba__label {
   color: var(--color-accent);
+}
+
+.hero-ba__text {
+  margin: 0;
+  font-size: 0.8rem;
+  font-weight: var(--fw-medium);
+  line-height: 1.35;
+  color: var(--color-text-muted);
+}
+
+.hero-ba__row--after .hero-ba__text {
+  color: var(--color-text);
+}
+
+.hero-ba__meta {
+  margin: 0.2rem 0 0;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+}
+
+.hero-ba__row--before .hero-ba__meta {
+  color: var(--color-text-muted);
+}
+
+.hero-ba__row--after .hero-ba__meta {
+  color: var(--color-success);
+}
+
+.hero-ba__footer {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.55rem 0.875rem;
+  border-top: 1px solid var(--color-border);
+  background: var(--color-surface-2);
+  font-family: var(--font-mono);
+  font-size: 0.65rem;
+  color: var(--color-text-muted);
+}
+
+.hero-ba__footer-icon {
+  width: 14px;
+  height: 14px;
+  color: var(--color-accent);
+  flex-shrink: 0;
 }
 
 @media (max-width: 56rem) {
   .hero__inner {
     grid-template-columns: 1fr;
   }
+}
 
-  .hero-panel__row {
-    grid-template-columns: auto 1fr;
-  }
-
-  .hero-panel__status {
-    grid-column: 1 / -1;
-    justify-self: start;
+@media (max-width: 40rem) {
+  .hero__visual {
+    display: none;
   }
 }
 </style>

--- a/i18n/locales/cs.json
+++ b/i18n/locales/cs.json
@@ -40,19 +40,28 @@
     "lead": "Navrhujeme AI agenty, znalostní systémy a automatizace, které pomáhají týmům vyhledávat informace, zpracovávat dokumenty a provádět opakující se úkoly.",
     "cta_contact": "Kontaktovat nás",
     "trust_microcopy": "Bezplatná ukázka na vašich datech · bez závazku",
-    "panel_caption": "Ukázka rozhraní — ilustrační data",
     "panel": {
-      "live_badge": "Ukázka",
-      "kind_agent": "AI agent",
-      "kind_search": "Vyhledávání",
-      "kind_automation": "Automatizace",
-      "kind_document": "Dokument",
-      "row_agent": "Odpověděl na otázku o stavu objednávky",
-      "row_search": "Našel smlouvu podle klíčových slov",
-      "row_automation": "Zpracoval e-mailovou objednávku",
-      "row_document": "Faktura — Velkoobchod Dřevo s.r.o.",
-      "status_done": "Hotovo",
-      "status_review": "Probíhá"
+      "tab_before": "← Předtím",
+      "tab_after": "Potom →",
+      "disclaimer": "Časy jsou ilustrační — reálné výsledky závisí na procesu",
+
+      "invoices_label": "Faktury",
+      "invoices_before": "Ruční přepis do účetnictví",
+      "invoices_before_meta": "~3 hod./den",
+      "invoices_after": "AI vytáhne údaje, vy schválíte",
+      "invoices_after_meta": "~8 sek./faktura",
+
+      "contracts_label": "Smlouvy",
+      "contracts_before": "Hledání na sdíleném disku",
+      "contracts_before_meta": "~20 min./dotaz",
+      "contracts_after": "Asistent odpoví s citací",
+      "contracts_after_meta": "~4 sek./dotaz",
+
+      "orders_label": "Objednávky",
+      "orders_before": "Ruční zadávání z e-mailů",
+      "orders_before_meta": "každý den",
+      "orders_after": "Agent zpracuje a zaeviduje",
+      "orders_after_meta": "automaticky"
     },
     "rotator": {
       "item_1": "Vytěží částky, IČO a splatnost z faktur.",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -40,19 +40,28 @@
     "lead": "We design AI agents, knowledge systems, and automations that help teams find information, process documents, and handle repetitive tasks.",
     "cta_contact": "Contact us",
     "trust_microcopy": "Free demo on your own data · no obligation",
-    "panel_caption": "Interface preview — illustrative data",
     "panel": {
-      "live_badge": "Preview",
-      "kind_agent": "AI agent",
-      "kind_search": "Search",
-      "kind_automation": "Automation",
-      "kind_document": "Document",
-      "row_agent": "Answered a question about order status",
-      "row_search": "Found a contract by keyword",
-      "row_automation": "Processed an email order",
-      "row_document": "Invoice — Drevo Wholesale Ltd.",
-      "status_done": "Done",
-      "status_review": "In progress"
+      "tab_before": "← Before",
+      "tab_after": "After →",
+      "disclaimer": "Times are illustrative — real results depend on your process",
+
+      "invoices_label": "Invoices",
+      "invoices_before": "Manual entry into accounting",
+      "invoices_before_meta": "~3 hrs/day",
+      "invoices_after": "AI extracts data, you approve",
+      "invoices_after_meta": "~8 sec/invoice",
+
+      "contracts_label": "Contracts",
+      "contracts_before": "Searching a shared drive",
+      "contracts_before_meta": "~20 min/query",
+      "contracts_after": "Assistant answers with a citation",
+      "contracts_after_meta": "~4 sec/query",
+
+      "orders_label": "Orders",
+      "orders_before": "Manual entry from emails",
+      "orders_before_meta": "every day",
+      "orders_after": "Agent processes and logs it",
+      "orders_after_meta": "automatically"
     },
     "rotator": {
       "item_1": "Extracts amounts, tax IDs, and due dates from invoices.",

--- a/i18n/locales/sk.json
+++ b/i18n/locales/sk.json
@@ -40,19 +40,28 @@
     "lead": "Navrhujeme AI agentov, znalostné systémy a automatizácie, ktoré pomáhajú tímom vyhľadávať informácie, spracovávať dokumenty a vykonávať opakujúce sa úlohy.",
     "cta_contact": "Kontaktovať nás",
     "trust_microcopy": "Bezplatné demo na vašich dátach · bez záväzku",
-    "panel_caption": "Ukážka rozhrania — ilustračné dáta",
     "panel": {
-      "live_badge": "Ukážka",
-      "kind_agent": "AI agent",
-      "kind_search": "Vyhľadávanie",
-      "kind_automation": "Automatizácia",
-      "kind_document": "Dokument",
-      "row_agent": "Odpovedal na otázku o stave objednávky",
-      "row_search": "Našiel zmluvu podľa kľúčových slov",
-      "row_automation": "Spracoval e-mailovú objednávku",
-      "row_document": "Faktúra — Veľkoobchod Drevo s.r.o.",
-      "status_done": "Hotovo",
-      "status_review": "Prebieha"
+      "tab_before": "← Predtým",
+      "tab_after": "Potom →",
+      "disclaimer": "Časy sú ilustračné — reálne výsledky závisia od procesu",
+
+      "invoices_label": "Faktúry",
+      "invoices_before": "Ručný prepis do účtovníctva",
+      "invoices_before_meta": "~3 hod./deň",
+      "invoices_after": "AI vytiahne údaje, vy schválite",
+      "invoices_after_meta": "~8 sek./faktúra",
+
+      "contracts_label": "Zmluvy",
+      "contracts_before": "Hľadanie v zdieľanom disku",
+      "contracts_before_meta": "~20 min./dotaz",
+      "contracts_after": "Asistent odpovie s citáciou",
+      "contracts_after_meta": "~4 sek./dotaz",
+
+      "orders_label": "Objednávky",
+      "orders_before": "Ručné zadávanie z e-mailov",
+      "orders_before_meta": "každý deň",
+      "orders_after": "Agent spracuje a zaeviduje",
+      "orders_after_meta": "automaticky"
     },
     "rotator": {
       "item_1": "Vyťaží sumy, IČO a splatnosť z faktúr.",


### PR DESCRIPTION
Implementácia \`.claude/projentiq_hero_SPEC_v2.md\` časti 1, 2 a 6. Časť 3 (voliteľné zmeny H1/rotátora) vynechaná podľa pokynu.

## Summary
Pôvodný hero panel miešal AI agenta/vyhľadávanie/automatizáciu/dokument do jedného zoznamu riadkov — návštevník za pár sekúnd nepochopil, čo presne dostane. Nový Pred/Po panel namiesto toho ukazuje konkrétnu bolesť (vľavo) a úľavu po nasadení (vpravo) pre tri prípady — faktúry, zmluvy, objednávky — s ilustračnými časmi.

- \`panelItems\` → \`baRows\`, \`.hero-panel\` markup/štýly → \`.hero-ba\` (dva tab-y „Predtým"/„Potom", 2-stĺpcový grid, disclaimer footer)
- Rotátor, H1/eyebrow/lead/CTA/trust-microcopy nedotknuté — presne podľa spec časti 0
- i18n \`hero.panel\` kľúče prerobené vo všetkých troch jazykoch
- Panel zostáva \`aria-hidden\` (dekoratívny), teraz sa skrýva na ≤40rem (predtým ≤56rem, podľa novej spec požiadavky)

## Kontrast — odklon od spec CSS
Spec časť 4 sama žiadala overiť \`--color-text-subtle\` na \`--color-surface-2\`. Zlyháva (3.43:1 dark, 2.82:1 light, treba 4.5:1). Nahradené \`--color-text-muted\` všade, kde ho spec CSS používal pre čitateľný text (tab--before, row--before label/meta, footer disclaimer) — vyhovuje s veľkou rezervou.

## Test plan
- [x] \`nuxt generate\` bez chýb
- [x] Vizuálna kontrola dark/light témy
- [x] Panel korektne mizne pri ≤40rem (overené pri 600px) a zostáva viditeľný pri >40rem (700px)
- [x] H1 stále bez \`.reveal\` triedy (LCP nedotknutý)
- [x] axe-core: 0 violations (sk/cs/en × dark/light)
- [x] Lighthouse: Accessibility/Best Practices/SEO 100/100/100 (Performance 92-95)
- [x] 0 console errors